### PR TITLE
Disk: Update Size value in example

### DIFF
--- a/Examples/Resources/Disk/1-Disk_InitializeDataDisk.ps1
+++ b/Examples/Resources/Disk/1-Disk_InitializeDataDisk.ps1
@@ -40,7 +40,7 @@ Configuration Disk_InitializeDataDisk
         {
              DiskId = 2
              DriveLetter = 'G'
-             Size = 10GB
+             Size = 10737418240
              DependsOn = '[WaitForDisk]Disk2'
         }
 
@@ -63,7 +63,7 @@ Configuration Disk_InitializeDataDisk
         {
              DiskId = 3
              DriveLetter = 'S'
-             Size = 100GB
+             Size = 107374182400
              FSFormat = 'ReFS'
              AllocationUnitSize = 64KB
              DependsOn = '[WaitForDisk]Disk3'


### PR DESCRIPTION
#### This Pull Request (PR) fixes the following issues
A value with a size unit (like MB or GB) does not work.
It generates the following error message:

> Compilation errors occurred while processing configuration 'DscConfigurationName'. Please review the errors reported in error stream and modify your configuration code appropriately.
> + CategoryInfo : InvalidOperation: (DscConfiguration:String) [], InvalidOperationException
> + FullyQualifiedErrorId : FailToProcessConfiguration

Entering only a number works fine.

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/storagedsc/214)
<!-- Reviewable:end -->
