### PR TITLE
MSFT_MountImage - Correcting example for dismounting an ISO image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed hash table style violations - fixes [Issue #219](https://github.com/PowerShell/StorageDsc/issues/219).
+- Updated [MountImage_DismountISO](https://github.com/dsccommunity/StorageDsc/blob/dev/Examples/Resources/MountImage/1-MountImage_DismountISO.ps1) to correct error - fixes [Issue #221](https://github.com/dsccommunity/StorageDsc/issues/221)
 
 ## 4.9.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Fixed hash table style violations - fixes [Issue #219](https://github.com/PowerShell/StorageDsc/issues/219).
-- Updated [MountImage_DismountISO](https://github.com/dsccommunity/StorageDsc/blob/dev/Examples/Resources/MountImage/1-MountImage_DismountISO.ps1) to correct error - fixes [Issue #221](https://github.com/dsccommunity/StorageDsc/issues/221)
+- Updated 1-MountImage_DismountISO.ps1 - fixes [Issue #221](https://github.com/dsccommunity/StorageDsc/issues/221)
 
 ## 4.9.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 4.9.0.0
+
 - Disk:
   - Added `Location` as a possible value for `DiskIdType`. This will select the
     disk based on the `Location` property returned by `Get-Disk`

--- a/Examples/Resources/MountImage/1-MountImage_DismountISO.ps1
+++ b/Examples/Resources/MountImage/1-MountImage_DismountISO.ps1
@@ -28,7 +28,6 @@ configuration MountImage_DismountISO
     MountImage ISO
     {
         ImagePath = 'c:\Sources\SQL.iso'
-        DriveLetter = 'S'
         Ensure = 'Absent'
     }
 }

--- a/StorageDsc.psd1
+++ b/StorageDsc.psd1
@@ -3,7 +3,7 @@
     # RootModule = ''
 
     # Version number of this module.
-    moduleVersion = '4.8.0.0'
+    moduleVersion = '4.9.0.0'
 
     # ID used to uniquely identify this module
     GUID                 = '00d73ca1-58b5-46b7-ac1a-5bfcf5814faf'
@@ -102,19 +102,18 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-        ReleaseNotes = '- Removed suppression of `PSUseShouldProcessForStateChangingFunctions` PSSA rule
-  because it is no longer required.
-- Combined all `StorageDsc.ResourceHelper` module functions into
-  `StorageDsc.Common` module and removed `StorageDsc.ResourceHelper`.
-- Opted into Common Tests "Common Tests - Validate Localization" -
-  fixes [Issue 206](https://github.com/PowerShell/StorageDsc/issues/206).
-- Refactored tests for `StorageDsc.Common` to meet latest standards.
-- Minor style corrections.
-- Removed unused localization strings from resources.
+        ReleaseNotes = '- Disk:
+  - Added `Location` as a possible value for `DiskIdType`. This will select the
+    disk based on the `Location` property returned by `Get-Disk`
+  - Maximum size calculation now uses workaround so that
+    Test-TargetResource works properly - workaround for
+    [Issue 181](https://github.com/PowerShell/StorageDsc/issues/181).
 - DiskAccessPath:
-  - Added function to force refresh of disk subsystem at the start of
-    Set-TargetResource to prevent errors occuring when the disk access
-    path is already assigned - See [Issue 121](https://github.com/PowerShell/StorageDsc/issues/121)
+  - Added `Location` as a possible value for `DiskIdType`. This will select the
+    disk based on the `Location` property returned by `Get-Disk`
+- WaitForDisk:
+  - Added `Location` as a possible value for `DiskIdType`. This will select the
+    disk based on the `Location` property returned by `Get-Disk`
 
 '
 
@@ -128,6 +127,7 @@
     # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
     # DefaultCommandPrefix = ''
 }
+
 
 
 


### PR DESCRIPTION
#### Pull Request (PR) description
The drive letter should not be provided when wanting to ensure an ISO is no longer mounted.

#### This Pull Request (PR) fixes the following issues

- Fixes #221 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/storagedsc/222)
<!-- Reviewable:end -->
