### PR TITLE
OpticalDiskDriveLetter: Suppress No Drive Exception - Fixes #194

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change Azure DevOps Pipeline definition to include `source/*` - Fixes [Issue #231](https://github.com/dsccommunity/StorageDsc/issues/231).
 - Updated pipeline to use `latest` version of `ModuleBuilder` - Fixes [Issue #231](https://github.com/dsccommunity/StorageDsc/issues/231).
 - Merge `HISTORIC_CHANGELOG.md` into `CHANGELOG.md` - Fixes [Issue #232](https://github.com/dsccommunity/StorageDsc/issues/232).
+- OpticalDiskDriveLetter:
+  - Suppress exception when requested optical disk drive does not exist
+    and Ensure is set to `Absent` - Fixes [Issue #194](https://github.com/dsccommunity/StorageDsc/issues/194).
 
 ## [4.9.0.0] - 2019-10-30
 

--- a/source/DSCResources/DSC_OpticalDiskDriveLetter/en-US/DSC_OpticalDiskDriveLetter.strings.psd1
+++ b/source/DSCResources/DSC_OpticalDiskDriveLetter/en-US/DSC_OpticalDiskDriveLetter.strings.psd1
@@ -2,6 +2,7 @@ ConvertFrom-StringData @'
     UsingGetCimInstanceToFetchDriveLetter = Using Get-CimInstance to get the drive letter of optical disk {0} in the system.
     OpticalDiskAssignedDriveLetter = The optical disk {0} is currently assigned drive letter '{1}'.
     OpticalDiskNotAssignedDriveLetter = The optical disk {0} is not currently assigned a drive letter.
+    OpticalDiskDriveDoesNotExist = The optical disk {0} could not be found in the system.
     NoOpticalDiskDriveError = The optical disk {0} could not be found in the system, so this resource has nothing to do. This resource does not change the drive letter of mounted ISOs.
 
     AttemptingToSetDriveLetter = The optical disk {0} drive letter is '{1}', attempting to set to '{2}'.

--- a/tests/Unit/DSC_OpticalDiskDriveLetter.Tests.ps1
+++ b/tests/Unit/DSC_OpticalDiskDriveLetter.Tests.ps1
@@ -107,7 +107,7 @@ try
         }
 
         Describe 'DSC_xOpticalDiskDriveLetter\Get-OpticalDiskDriveLetter' {
-            Context 'Single optical disk drive present and assigned a drive letter' {
+            Context 'When a single optical disk drive is present and assigned a drive letter' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
@@ -135,7 +135,7 @@ try
                 }
             }
 
-            Context 'Single optical disk drive present and not assiged a drive letter' {
+            Context 'When a single optical disk drive is present and not assiged a drive letter' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
@@ -164,7 +164,7 @@ try
                 }
             }
 
-            Context 'Multiple optical disk drives present and second one is assigned a drive letter' {
+            Context 'When multiple optical disk drives are present and second one is assigned a drive letter' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
@@ -192,27 +192,27 @@ try
                 }
             }
 
-            Context 'Single optical disk drive present but second disk is requested' {
+            Context 'When a single optical disk drive is present but second disk is requested' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedOpticalDrive
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedOpticalDrive
+                    } `
                     -Verifiable
 
-                $errorRecord = Get-InvalidArgumentRecord `
-                    -Message ($LocalizedData.NoOpticalDiskDriveError -f 2) `
-                    -ArgumentName 'DiskId'
-
-                It 'Should throw expected exception' {
+                It 'Should not throw exception' {
                     {
                         $script:result = Get-OpticalDiskDriveLetter `
                             -DiskId 2 `
                             -Verbose
-                    } | Should -Throw $errorRecord
+                    } | Should -Not -Throw
+                }
+
+                It 'DeviceId should be empty' {
+                    $script:result.DeviceId | Should -BeNullOrEmpty
                 }
 
                 It 'Should call all the Get mocks' {
@@ -220,23 +220,55 @@ try
                 }
             }
 
-            Context 'Single optical disk drive present but is mounted with ISO' {
+            Context 'When a single optical disk drive is present but is mounted with ISO' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedOpticalDriveISO
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedOpticalDriveISO
+                    } `
                     -Verifiable
 
-                It 'Should throw expected exception' {
+                It 'Should not throw exception' {
                     {
                         $script:result = Get-OpticalDiskDriveLetter `
                             -DiskId 1 `
                             -Verbose
-                    } | Should -Throw $errorRecord
+                    } | Should -Not -Throw
+                }
+
+                It 'DeviceId should be empty' {
+                    $script:result.DeviceId | Should -BeNullOrEmpty
+                }
+
+                It 'Should call all the Get mocks' {
+                    Assert-VerifiableMock
+                }
+            }
+
+            Context 'When no optical disk drives are present in the system' {
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -ParameterFilter {
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedNoOpticalDrive
+                    } `
+                    -Verifiable
+
+                It 'Should not throw exception' {
+                    {
+                        $script:result = Get-OpticalDiskDriveLetter `
+                            -DiskId 1 `
+                            -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'DeviceId should be empty' {
+                    $script:result.DeviceId | Should -BeNullOrEmpty
                 }
 
                 It 'Should call all the Get mocks' {
@@ -246,15 +278,15 @@ try
         }
 
         Describe 'DSC_OpticalDiskDriveLetter\Get-TargetResource' {
-            Context 'Optical disk drive present with correct drive letter' {
+            Context 'When an optical disk drive is present with correct drive letter' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedOpticalDrive
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedOpticalDrive
+                    } `
                     -Verifiable
 
                 It 'Should not throw an exception' {
@@ -276,15 +308,15 @@ try
                 }
             }
 
-            Context 'Optical disk drive present with incorrect drive letter' {
+            Context 'When an optical disk drive is present with incorrect drive letter' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedWrongLetterOpticalDrive
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedWrongLetterOpticalDrive
+                    } `
                     -Verifiable
 
                 It 'Should not throw an exception' {
@@ -306,15 +338,15 @@ try
                 }
             }
 
-            Context 'IDE optical disk drive present with incorrect drive letter' {
+            Context 'When an IDE optical disk drive is present with incorrect drive letter' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedOpticalDriveIDE
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedOpticalDriveIDE
+                    } `
                     -Verifiable
 
                 It 'Should not throw an exception' {
@@ -336,28 +368,30 @@ try
                 }
             }
 
-            Context 'Optical disk drive not present' {
+            Context 'When an optical disk drive is not present' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedNoOpticalDrive
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedNoOpticalDrive
+                    } `
                     -Verifiable
 
-                $errorRecord = Get-InvalidArgumentRecord `
-                    -Message ($LocalizedData.NoOpticalDiskDriveError -f 1) `
-                    -ArgumentName 'DiskId'
-
-                It 'Should throw expected exception' {
+                It 'Should not throw exception' {
                     {
                         $script:result = Get-TargetResource `
                             -DiskId 1 `
                             -Driveletter $script:testDriveLetter `
                             -Verbose
-                    } | Should -Throw $errorRecord
+                    } | Should -Not -Throw
+                }
+
+                It 'Should have an empty DriveLetter and Ensure is Absent' {
+                    $script:result.DriveLetter | Should -BeNullOrEmpty
+                    $script:result.DiskId | Should -Be 1
+                    $script:result.Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should call all the Get mocks' {
@@ -367,15 +401,15 @@ try
         }
 
         Describe 'DSC_OpticalDiskDriveLetter\Set-TargetResource' {
-            Context 'Optical disk drive exists with the correct drive letter' {
+            Context 'When an optical disk drive exists with the correct drive letter' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedOpticalDrive
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedOpticalDrive
+                    } `
                     -Verifiable
 
                 It 'Should not throw an exception' {
@@ -393,25 +427,25 @@ try
                 }
             }
 
-            Context 'Optical disk drive exists with a drive letter when Ensure is set to Absent' {
+            Context 'When an optical disk drive exists with a drive letter when Ensure is set to Absent' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedOpticalDrive
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedOpticalDrive
+                    } `
                     -Verifiable
 
                 Mock `
                     -CommandName Get-CimInstance  `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_Volume'
-                } `
-                    -MockWith {
-                    $script:mockedVolume
-                } `
+                        $ClassName -eq 'Win32_Volume'
+                    } `
+                        -MockWith {
+                        $script:mockedVolume
+                    } `
                     -Verifiable
 
                 Mock `
@@ -434,25 +468,25 @@ try
                 }
             }
 
-            Context 'Optical disk drive exists with the wrong drive letter' {
+            Context 'When an optical disk drive exists with the wrong drive letter' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedWrongLetterOpticalDrive
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedWrongLetterOpticalDrive
+                    } `
                     -Verifiable
 
                 Mock `
                     -CommandName Get-CimInstance  `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_Volume'
-                } `
-                    -MockWith {
-                    $script:mockedWrongVolume
-                } `
+                        $ClassName -eq 'Win32_Volume'
+                    } `
+                        -MockWith {
+                        $script:mockedWrongVolume
+                    } `
                     -Verifiable
 
                 Mock `
@@ -475,25 +509,25 @@ try
                 }
             }
 
-            Context 'IDE optical disk drive exists with the wrong drive letter' {
+            Context 'When an IDE optical disk drive exists with the wrong drive letter' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedOpticalDriveIDE
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedOpticalDriveIDE
+                    } `
                     -Verifiable
 
                 Mock `
                     -CommandName Get-CimInstance  `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_Volume'
-                } `
-                    -MockWith {
-                    $script:mockedWrongVolume
-                } `
+                        $ClassName -eq 'Win32_Volume'
+                    } `
+                        -MockWith {
+                        $script:mockedWrongVolume
+                    } `
                     -Verifiable
 
                 Mock `
@@ -516,28 +550,24 @@ try
                 }
             }
 
-            Context 'Optical disk drive not present' {
+            Context 'When an optical disk drive is not present' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedNoOpticalDrive
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedNoOpticalDrive
+                    } `
                     -Verifiable
 
-                $errorRecord = Get-InvalidArgumentRecord `
-                    -Message ($LocalizedData.NoOpticalDiskDriveError -f 1) `
-                    -ArgumentName 'DiskId'
-
-                It 'Should throw expected exception' {
+                It 'Should not throw exception' {
                     {
                         $script:result = Set-TargetResource `
                             -DiskId 1 `
                             -Driveletter $script:testDriveLetter `
                             -Verbose
-                    } | Should -Throw $errorRecord
+                    } | Should -Not -Throw
                 }
 
                 It 'Should call all the Get mocks' {
@@ -547,15 +577,15 @@ try
         }
 
         Describe 'DSC_OpticalDiskDriveLetter\Test-TargetResource' {
-            Context 'Optical drive exists and is assigned expected drive letter' {
+            Context 'When the optical drive exists and is assigned expected drive letter' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedOpticalDrive
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedOpticalDrive
+                    } `
                     -Verifiable
 
                 It 'Should not throw an exception' {
@@ -568,7 +598,7 @@ try
                 }
 
                 It 'Should return $true' {
-                    $script:result | Should -Be $true
+                    $script:result | Should -BeTrue
                 }
 
                 It 'Should call all the Get mocks' {
@@ -576,15 +606,15 @@ try
                 }
             }
 
-            Context 'Optical drive exists but is assigned a drive letter but should not be' {
+            Context 'When the optical drive exists but is assigned a drive letter but should not be' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedOpticalDrive
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedOpticalDrive
+                    } `
                     -Verifiable
 
                 It 'Should not throw an exception' {
@@ -598,7 +628,7 @@ try
                 }
 
                 It 'Should return $false' {
-                    $script:result | Should -Be $false
+                    $script:result | Should -BeFalse
                 }
 
                 It 'Should call all the Get mocks' {
@@ -606,7 +636,7 @@ try
                 }
             }
 
-            Context 'The drive letter already exists on a volume that is not an optical disk drive' {
+            Context 'When the drive letter already exists on a volume that is not an optical disk drive' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
@@ -620,11 +650,11 @@ try
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_Volume'
-                } `
-                    -MockWith {
-                    $script:mockedVolume
-                } `
+                        $ClassName -eq 'Win32_Volume'
+                    } `
+                        -MockWith {
+                        $script:mockedVolume
+                    } `
                     -Verifiable
 
                 $errorRecord = Get-InvalidOperationRecord `
@@ -644,15 +674,15 @@ try
                 }
             }
 
-            Context 'The optical drive is assigned a drive letter but should not be' {
+            Context 'When the optical drive is assigned a drive letter but should not be' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedOpticalDrive
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedOpticalDrive
+                    } `
                     -Verifiable
 
                 It 'Should not throw an exception' {
@@ -666,7 +696,7 @@ try
                 }
 
                 It 'Should return $false' {
-                    $script:result | Should -Be $false
+                    $script:result | Should -BeFalse
                 }
 
                 It 'Should call all the Get mocks' {
@@ -674,15 +704,15 @@ try
                 }
             }
 
-            Context 'The optical drive is not assigned a drive letter and should not be' {
+            Context 'When the optical drive is not assigned a drive letter and should not be' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
-                    -MockWith {
-                    $script:mockedOpticalDriveNoDriveLetter
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                        -MockWith {
+                        $script:mockedOpticalDriveNoDriveLetter
+                    } `
                     -Verifiable
 
                 It 'Should not throw an exception' {
@@ -696,7 +726,7 @@ try
                 }
 
                 It 'Should return $true' {
-                    $script:result | Should -Be $true
+                    $script:result | Should -BeTrue
                 }
 
                 It 'Should call all the Get mocks' {
@@ -704,15 +734,15 @@ try
                 }
             }
 
-            Context 'Optical disk drive not present' {
+            Context 'When the optical drive does not exist and Ensure is Present' {
                 Mock `
                     -CommandName Get-CimInstance `
                     -ParameterFilter {
-                    $ClassName -eq 'Win32_CDROMDrive'
-                } `
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
                     -MockWith {
-                    $script:mockedNoOpticalDrive
-                } `
+                        $script:mockedNoOpticalDrive
+                    } `
                     -Verifiable
 
                 $errorRecord = Get-InvalidArgumentRecord `
@@ -726,6 +756,36 @@ try
                             -Driveletter $script:testDriveLetter `
                             -Verbose
                     } | Should -Throw $errorRecord
+                }
+
+                It 'Should call all the Get mocks' {
+                    Assert-VerifiableMock
+                }
+            }
+
+            Context 'When the optical drive does not exist and Ensure is Absent' {
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -ParameterFilter {
+                        $ClassName -eq 'Win32_CDROMDrive'
+                    } `
+                    -MockWith {
+                        $script:mockedNoOpticalDrive
+                    } `
+                    -Verifiable
+
+                It 'Should not throw an exception' {
+                    {
+                        $script:result = Test-TargetResource `
+                            -DiskId 1 `
+                            -DriveLetter $script:testDriveLetter `
+                            -Ensure 'Absent' `
+                            -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should return $true' {
+                    $script:result | Should -BeTrue
                 }
 
                 It 'Should call all the Get mocks' {


### PR DESCRIPTION
#### Pull Request (PR) description

Suppress exception when requested optical disk drive does not exist and Ensure is set to `Absent`

#### This Pull Request (PR) fixes the following issues

 - Fixes #194

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju  - can you review for me when you get time?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/storagedsc/235)
<!-- Reviewable:end -->
