### PR TITLE
Disk: Fix bug when Partition reported twice - Fixes #210

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - StorageDsc
   - Automatically publish documentation to GitHub Wiki - Fixes [Issue #241](https://github.com/dsccommunity/StorageDsc/issues/241).
 
+### Fixed
+
+- Disk:
+  - Fix bug when multiple partitions with the same drive letter are
+    reported by the disk subsystem - Fixes [Issue #210](https://github.com/dsccommunity/StorageDsc/issues/210).
+
 ## [5.0.0] - 2020-05-05
 
 ### Changed

--- a/source/DSCResources/DSC_Disk/DSC_Disk.psm1
+++ b/source/DSCResources/DSC_Disk/DSC_Disk.psm1
@@ -117,7 +117,7 @@ function Get-TargetResource
 
     $partition = Get-Partition `
         -DriveLetter $DriveLetter `
-        -ErrorAction SilentlyContinue
+        -ErrorAction SilentlyContinue | Select-Object -First 1
 
     $volume = Get-Volume `
         -DriveLetter $DriveLetter `
@@ -794,7 +794,7 @@ function Test-TargetResource
 
     $partition = Get-Partition `
         -DriveLetter $DriveLetter `
-        -ErrorAction SilentlyContinue
+        -ErrorAction SilentlyContinue | Select-Object -First 1
 
     if ($partition.DriveLetter -ne $DriveLetter)
     {


### PR DESCRIPTION
#### Pull Request (PR) description

- Fix bug when multiple partitions with the same drive letter are
    reported by the disk subsystem - Fixes [Issue #210](https://github.com/dsccommunity/StorageDsc/issues/210).

#### This Pull Request (PR) fixes the following issues

- Fixes #210 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing this one for me?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/storagedsc/243)
<!-- Reviewable:end -->
