### PR TITLE
OpticalDiskDriveLetter: Fix finding drive on Azure Windows Server 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added support for changing optical disk drive letter on Windows Server 2022 - Fixes [Issue #274](https://github.com/dsccommunity/StorageDsc/issues/274)
+
 ## [5.1.0] - 2023-02-22
 
 ### Changed

--- a/source/DSCResources/DSC_OpticalDiskDriveLetter/DSC_OpticalDiskDriveLetter.psm1
+++ b/source/DSCResources/DSC_OpticalDiskDriveLetter/DSC_OpticalDiskDriveLetter.psm1
@@ -12,6 +12,36 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 
 <#
     .SYNOPSIS
+        This helper function returns the expected max length of the Win32_CDROMDrive
+        DeviceId, based on the BuildId of the operating system.
+
+    .NOTES
+        Pre Windows Server 2022 the expected max length is 10,
+        from Windows Server 2022 onwards this is 20.
+#>
+function Get-OpticalDeviceIdMaxLength
+{
+    [CmdletBinding()]
+    param()
+
+    Write-Verbose -Message ( @(
+            "$($MyInvocation.MyCommand): "
+            $($script:localizedData.UsingGetCimInstanceToFetchDeviceIdMaxLength -f $DiskId)
+        ) -join '' )
+
+    if ((Get-CimInstance -ClassName WIN32_OperatingSystem).BuildNumber -ge 20348)
+    {
+        $Length = 20
+    }
+    else
+    {
+        $Length = 10
+    }
+    return $Length
+}
+
+<#
+    .SYNOPSIS
         This helper function returns a hashtable containing the current
         drive letter assigned to the optical disk in the system matching
         the disk number.
@@ -59,7 +89,7 @@ function Get-OpticalDiskDriveLetter
         Where-Object -FilterScript {
         -not (
             $_.Caption -eq 'Microsoft Virtual DVD-ROM' -and
-            ($_.DeviceID.Split('\')[-1]).Length -gt 10
+            ($_.DeviceID.Split('\')[-1]).Length -gt (Get-OpticalDeviceIdMaxLength)
         )
     }
 

--- a/source/DSCResources/DSC_OpticalDiskDriveLetter/en-US/DSC_OpticalDiskDriveLetter.strings.psd1
+++ b/source/DSCResources/DSC_OpticalDiskDriveLetter/en-US/DSC_OpticalDiskDriveLetter.strings.psd1
@@ -1,4 +1,5 @@
 ConvertFrom-StringData @'
+    UsingGetCimInstanceToFetchDeviceIdMaxLength = Using Get-CimInstance to get the expected max length of optical disk {0}'s DeviceId.
     UsingGetCimInstanceToFetchDriveLetter = Using Get-CimInstance to get the drive letter of optical disk {0} in the system.
     OpticalDiskAssignedDriveLetter = The optical disk {0} is currently assigned drive letter '{1}'.
     OpticalDiskNotAssignedDriveLetter = The optical disk {0} is not currently assigned a drive letter.

--- a/tests/Unit/DSC_OpticalDiskDriveLetter.Tests.ps1
+++ b/tests/Unit/DSC_OpticalDiskDriveLetter.Tests.ps1
@@ -92,6 +92,17 @@ try
             Id          = 'W:'
         }
 
+        $script:mockedOSPreServer2022 = [pscustomobject] @{
+            BuildNumber = 17763
+        }
+
+        $script:mockedOSServer2022 = [pscustomobject] @{
+            BuildNumber = 20348
+        }
+
+        $script:opticalDeviceIdMaxLengthPreServer2022 = 10
+        $script:opticalDeviceIdMaxLengthServer2022 = 20
+
         function Set-CimInstance
         {
             Param
@@ -104,6 +115,60 @@ try
                 [hashtable]
                 $Property
             )
+        }
+
+        Describe 'DSC_xOpticalDiskDriveLetter\Get-OpticalDeviceIdMaxLength' {
+            Context 'When OS is pre Windows Server 2022' {
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -ParameterFilter {
+                    $ClassName -eq 'WIN32_OperatingSystem'
+                } `
+                    -MockWith {
+                    $script:mockedOSPreServer2022
+                } `
+                    -Verifiable
+
+                It 'Should not throw an exception' {
+                    {
+                        $script:result = Get-OpticalDeviceIdMaxLength
+                    } | Should -Not -Throw
+                }
+
+                It "Optical DeviceId max length should be $($script:opticalDeviceIdMaxLengthPreServer2022)" {
+                    $script:result | Should -Be $script:opticalDeviceIdMaxLengthPreServer2022
+                }
+
+                It 'Should call all the Get mocks' {
+                    Assert-VerifiableMock
+                }
+            }
+
+            Context 'When OS is Windows Server 2022' {
+                Mock `
+                    -CommandName Get-CimInstance `
+                    -ParameterFilter {
+                    $ClassName -eq 'WIN32_OperatingSystem'
+                } `
+                    -MockWith {
+                    $script:mockedOSServer2022
+                } `
+                    -Verifiable
+
+                It 'Should not throw an exception' {
+                    {
+                        $script:result = Get-OpticalDeviceIdMaxLength
+                    } | Should -Not -Throw
+                }
+
+                It "Optical DeviceId max length should be $($script:opticalDeviceIdMaxLengthServer2022)" {
+                    $script:result | Should -Be $script:opticalDeviceIdMaxLengthServer2022
+                }
+
+                It 'Should call all the Get mocks' {
+                    Assert-VerifiableMock
+                }
+            }
         }
 
         Describe 'DSC_xOpticalDiskDriveLetter\Get-OpticalDiskDriveLetter' {


### PR DESCRIPTION
#### Pull Request (PR) description

Added support for changing optical disk drive letter on Windows Server 2022 where the DeviceId appears to be longer than 10 characters in length.

#### This Pull Request (PR) fixes the following issues

- Fixes #274

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
