### PR TITLE
Remove space between 'Dev Drive' tag  in psd1 file so deployment passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disk:
   - BREAKING CHANGE: Added support for volumes to be formatted as Dev Drives - Fixes [Issue #276](https://github.com/dsccommunity/StorageDsc/issues/276)
+- Updated tag from 'Dev Drive' to 'DevDrive' in manifest file - Fixes [Issue #280](https://github.com/dsccommunity/StorageDsc/issues/280)
+
 
 ## [5.1.0] - 2023-02-22
 

--- a/source/StorageDsc.psd1
+++ b/source/StorageDsc.psd1
@@ -52,7 +52,7 @@
             Prerelease   = ''
 
             # Tags applied to this module. These help with module discovery in online galleries.
-            Tags         = @('DesiredStateConfiguration', 'DSC', 'DSCResource', 'Disk', 'Storage', 'Partition', 'Volume', 'Dev Drive')
+            Tags         = @('DesiredStateConfiguration', 'DSC', 'DSCResource', 'Disk', 'Storage', 'Partition', 'Volume', 'DevDrive')
 
             # A URL to the license for this module.
             LicenseUri   = 'https://github.com/dsccommunity/StorageDsc/blob/main/LICENSE'


### PR DESCRIPTION
#### Pull Request (PR) description

This PR removes the whitespace between the 'Dev Drive'  tag in the psd1 file. This should allow the deployment to pass. Thats my bad for doing a find and replace in the previous PR. 

#### This Pull Request (PR) fixes the following issues

- Fixes #280 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [ ] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/StorageDsc/281)
<!-- Reviewable:end -->
