### PR TITLE
OpticalDiskDrive prevent exception on unmanageable device condition - Fixes #289

### DIFF
--- a/.vscode/analyzersettings.psd1
+++ b/.vscode/analyzersettings.psd1
@@ -1,7 +1,6 @@
 @{
     CustomRulePath      = @(
         './output/RequiredModules/DscResource.AnalyzerRules'
-        './tests/QA/AnalyzerRules/SqlServerDsc.AnalyzerRules.psm1'
         './output/RequiredModules/Indented.ScriptAnalyzerRules'
     )
     IncludeDefaultRules = $true

--- a/.vscode/analyzersettings.psd1
+++ b/.vscode/analyzersettings.psd1
@@ -1,44 +1,116 @@
 @{
-    CustomRulePath      = '.\output\RequiredModules\DscResource.AnalyzerRules'
-    includeDefaultRules = $true
-    IncludeRules   = @(
-        # DSC Resource Kit style guideline rules.
-        'PSAvoidDefaultValueForMandatoryParameter',
-        'PSAvoidDefaultValueSwitchParameter',
-        'PSAvoidInvokingEmptyMembers',
-        'PSAvoidNullOrEmptyHelpMessageAttribute',
-        'PSAvoidUsingCmdletAliases',
-        'PSAvoidUsingComputerNameHardcoded',
-        'PSAvoidUsingDeprecatedManifestFields',
-        'PSAvoidUsingEmptyCatchBlock',
-        'PSAvoidUsingInvokeExpression',
-        'PSAvoidUsingPositionalParameters',
-        'PSAvoidShouldContinueWithoutForce',
-        'PSAvoidUsingWMICmdlet',
-        'PSAvoidUsingWriteHost',
-        'PSDSCReturnCorrectTypesForDSCFunctions',
-        'PSDSCStandardDSCFunctionsInResource',
-        'PSDSCUseIdenticalMandatoryParametersForDSC',
-        'PSDSCUseIdenticalParametersForDSC',
-        'PSMisleadingBacktick',
-        'PSMissingModuleManifestField',
-        'PSPossibleIncorrectComparisonWithNull',
-        'PSProvideCommentHelp',
-        'PSReservedCmdletChar',
-        'PSReservedParams',
-        'PSUseApprovedVerbs',
-        'PSUseCmdletCorrectly',
-        'PSUseOutputTypeCorrectly',
-        'PSAvoidGlobalVars',
-        'PSAvoidUsingConvertToSecureStringWithPlainText',
-        'PSAvoidUsingPlainTextForPassword',
-        'PSAvoidUsingUsernameAndPasswordParams',
-        'PSDSCUseVerboseMessageInDSCResource',
-        'PSShouldProcess',
-        'PSUseDeclaredVarsMoreThanAssignments',
-        'PSUsePSCredentialType',
+    CustomRulePath      = @(
+        './output/RequiredModules/DscResource.AnalyzerRules'
+        './tests/QA/AnalyzerRules/SqlServerDsc.AnalyzerRules.psm1'
+        './output/RequiredModules/Indented.ScriptAnalyzerRules'
+    )
+    IncludeDefaultRules = $true
+    IncludeRules        = @(
+        # DSC Community style guideline rules from the module ScriptAnalyzer.
+        'PSAvoidDefaultValueForMandatoryParameter'
+        'PSAvoidDefaultValueSwitchParameter'
+        'PSAvoidInvokingEmptyMembers'
+        'PSAvoidNullOrEmptyHelpMessageAttribute'
+        'PSAvoidUsingCmdletAliases'
+        'PSAvoidUsingComputerNameHardcoded'
+        'PSAvoidUsingDeprecatedManifestFields'
+        'PSAvoidUsingEmptyCatchBlock'
+        'PSAvoidUsingInvokeExpression'
+        'PSAvoidUsingPositionalParameters'
+        'PSAvoidShouldContinueWithoutForce'
+        'PSAvoidUsingWMICmdlet'
+        'PSAvoidUsingWriteHost'
+        'PSDSCReturnCorrectTypesForDSCFunctions'
+        'PSDSCStandardDSCFunctionsInResource'
+        'PSDSCUseIdenticalMandatoryParametersForDSC'
+        'PSDSCUseIdenticalParametersForDSC'
+        'PSMisleadingBacktick'
+        'PSMissingModuleManifestField'
+        'PSPossibleIncorrectComparisonWithNull'
+        'PSProvideCommentHelp'
+        'PSReservedCmdletChar'
+        'PSReservedParams'
+        'PSUseApprovedVerbs'
+        'PSUseCmdletCorrectly'
+        'PSUseOutputTypeCorrectly'
+        'PSAvoidGlobalVars'
+        'PSAvoidUsingConvertToSecureStringWithPlainText'
+        'PSAvoidUsingPlainTextForPassword'
+        'PSAvoidUsingUsernameAndPasswordParams'
+        'PSDSCUseVerboseMessageInDSCResource'
+        'PSShouldProcess'
+        'PSUseDeclaredVarsMoreThanAssignments'
+        'PSUsePSCredentialType'
 
+        # Additional rules from the module ScriptAnalyzer
+        'PSUseConsistentWhitespace'
+        'UseCorrectCasing'
+        'PSPlaceOpenBrace'
+        'PSPlaceCloseBrace'
+        'AlignAssignmentStatement'
+        'AvoidUsingDoubleQuotesForConstantString'
+        'UseShouldProcessForStateChangingFunctions'
+
+        # Rules from the modules DscResource.AnalyzerRules
         'Measure-*'
+
+        # Rules from the module Indented.ScriptAnalyzerRules
+        'AvoidCreatingObjectsFromAnEmptyString'
+        'AvoidDashCharacters'
+        'AvoidEmptyNamedBlocks'
+        'AvoidFilter'
+        'AvoidHelpMessage'
+        'AvoidNestedFunctions'
+        'AvoidNewObjectToCreatePSObject'
+        'AvoidParameterAttributeDefaultValues'
+        'AvoidProcessWithoutPipeline'
+        'AvoidSmartQuotes'
+        'AvoidThrowOutsideOfTry'
+        'AvoidWriteErrorStop'
+        'AvoidWriteOutput'
+        'UseSyntacticallyCorrectExamples'
     )
 
+    <#
+        The following types are not rules but parse errors reported by PSScriptAnalyzer
+        so they cannot be ecluded. They need to be filtered out from the result of
+        Invoke-ScriptAnalyzer.
+
+        TypeNotFound - Because classes in the project cannot be found unless built.
+        RequiresModuleInvalid - Because 'using module' in prefix.ps1 cannot be resolved as source file.
+    #>
+    ExcludeRules        = @()
+
+    Rules               = @{
+        PSUseConsistentWhitespace  = @{
+            Enable                          = $true
+            CheckOpenBrace                  = $true
+            CheckInnerBrace                 = $true
+            CheckOpenParen                  = $true
+            CheckOperator                   = $false
+            CheckSeparator                  = $true
+            CheckPipe                       = $true
+            CheckPipeForRedundantWhitespace = $true
+            CheckParameter                  = $false
+        }
+
+        PSPlaceOpenBrace           = @{
+            Enable             = $true
+            OnSameLine         = $false
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $false
+        }
+
+        PSPlaceCloseBrace          = @{
+            Enable             = $true
+            NoEmptyLineBefore  = $true
+            IgnoreOneLineBlock = $false
+            NewLineAfter       = $true
+        }
+
+        PSAlignAssignmentStatement = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,16 +7,22 @@
     "powershell.codeFormatting.whitespaceAroundOperator": true,
     "powershell.codeFormatting.whitespaceAfterSeparator": true,
     "powershell.codeFormatting.ignoreOneLineBlock": false,
-    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationAfterEveryPipeline",
+    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
     "powershell.codeFormatting.preset": "Custom",
     "powershell.codeFormatting.alignPropertyValuePairs": true,
-    "files.trimTrailingWhitespace": true,
-    "files.insertFinalNewline": true,
-    "powershell.scriptAnalysis.settingsPath": ".vscode\\analyzersettings.psd1",
+    "powershell.codeFormatting.useConstantStrings": true,
+    "powershell.developer.bundledModulesPath": "${cwd}/output/RequiredModules",
+    "powershell.scriptAnalysis.settingsPath": "/.vscode/analyzersettings.psd1",
     "powershell.scriptAnalysis.enable": true,
+    "files.trimTrailingWhitespace": true,
+    "files.trimFinalNewlines": true,
+    "files.insertFinalNewline": true,
     "files.associations": {
         "*.ps1xml": "xml"
     },
+    "cSpell.dictionaries": [
+        "powershell"
+    ],
     "cSpell.words": [
         "COMPANYNAME",
         "ICONURI",
@@ -32,7 +38,21 @@
         "pscmdlet",
         "steppable"
     ],
+    "cSpell.ignorePaths": [
+        ".git"
+    ],
     "[markdown]": {
+        "files.trimTrailingWhitespace": true,
         "files.encoding": "utf8"
-    }
+    },
+    "powershell.pester.useLegacyCodeLens": false,
+    "pester.testFilePath": [
+        "[tT]ests/[qQ][aA]/*.[tT]ests.[pP][sS]1",
+        "[tT]ests/[uU]nit/**/*.[tT]ests.[pP][sS]1",
+        "[tT]ests/[uU]nit/*.[tT]ests.[pP][sS]1"
+    ],
+    "pester.runTestsInNewProcess": true,
+    "pester.pesterModulePath": "./output/RequiredModules/Pester",
+    "powershell.pester.codeLens": true,
+    "pester.suppressCodeLensNotice": true,
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     exception from occuring by marking disk as not manageable - Fixes [Issue #289](https://github.com/dsccommunity/StorageDsc/issues/289).
 - Azure DevOps Build Pipeline:
   - Update pipeline files to use latest DSC Community pattern and sampler tasks.
-  - Update pipeline to use `PublishCodeCoverageResults@2` task to publish code coverage results.
 
 ## [6.0.0] - 2024-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     exception to occur in the `Test-OpticalDiskCanBeManaged`. Prevented this
     exception from occuring by marking disk as not manageable - Fixes [Issue #289](https://github.com/dsccommunity/StorageDsc/issues/289).
 - Azure DevOps Build Pipeline:
-  - Update pipeline files to use latest DSC Community pattern and sampler tasks.invok
+  - Update pipeline files to use latest DSC Community pattern and sampler tasks.
+  - Update pipeline to use `PublishCodeCoverageResults@2` task to publish code coverage results.
 
 ## [6.0.0] - 2024-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- OpticalDiskDriveLetter:
+  - Some operating systems report the optical disk in the Win32_CDROMDrive list,
+    but a volume that matches either the DeviceId or DriveLetter can not be found.
+    This caused an `Cannot bind argument to parameter 'DevicePath' because it is an empty string.`
+    exception to occur in the `Test-OpticalDiskCanBeManaged`. Prevented this
+    exception from occuring by marking disk as not manageable - Fixes [Issue #289](https://github.com/dsccommunity/StorageDsc/issues/289).
+- Azure DevOps Build Pipeline:
+  - Update pipeline files to use latest DSC Community pattern and sampler tasks.invok
+
 ## [6.0.0] - 2024-03-19
 
 ### Added

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 mode: ContinuousDelivery
-next-version: 4.9.0
-major-version-bump-message: '\s?(breaking|major|breaking\schange)'
-minor-version-bump-message: '\s?(add|feature|minor)'
+next-version: 4.1.0
+major-version-bump-message: '(breaking\schange|breaking)\b'
+minor-version-bump-message: '(adds?|minor)\b'
 patch-version-bump-message: '\s?(fix|patch)'
 no-bump-message: '\+semver:\s?(none|skip)'
 assembly-informational-format: '{NuGetVersionV2}+Sha.{Sha}.Date.{CommitDate}'
@@ -21,6 +21,7 @@ branches:
     increment: Patch
     regex: (hot)?fix(es)?[\/-]
     source-branches: ['master']
+
 ignore:
   sha: []
 merge-message-formats: {}

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -11,6 +11,7 @@
     PSScriptAnalyzer            = 'latest'
     Pester                      = '4.10.1'
     Plaster                     = 'latest'
+    PlatyPS                     = 'latest'
     ModuleBuilder               = 'latest'
     ChangelogManagement         = 'latest'
     Sampler                     = 'latest'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -11,15 +11,22 @@
     PSScriptAnalyzer            = 'latest'
     Pester                      = '4.10.1'
     Plaster                     = 'latest'
-    PlatyPS                     = 'latest'
     ModuleBuilder               = 'latest'
     ChangelogManagement         = 'latest'
     Sampler                     = 'latest'
     'Sampler.GitHubTasks'       = 'latest'
     MarkdownLinkCheck           = 'latest'
     'DscResource.Test'          = 'latest'
-    'DscResource.AnalyzerRules' = 'latest'
-    'DscResource.DocGenerator'  = 'latest'
-    'DscResource.Common'        = 'latest'
     xDscResourceDesigner        = 'latest'
+
+    # Build dependencies needed for using the module
+    'DscResource.Common'           = 'latest'
+
+    # Analyzer rules
+    'DscResource.AnalyzerRules'    = 'latest'
+    'Indented.ScriptAnalyzerRules' = 'latest'
+
+    # Prerequisite modules for documentation.
+    'DscResource.DocGenerator'     = 'latest'
+    PlatyPS                        = 'latest'
 }

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -1,288 +1,1060 @@
+<#
+    .DESCRIPTION
+        Bootstrap script for PSDepend.
+
+    .PARAMETER DependencyFile
+        Specifies the configuration file for the this script. The default value is
+        'RequiredModules.psd1' relative to this script's path.
+
+    .PARAMETER PSDependTarget
+        Path for PSDepend to be bootstrapped and save other dependencies.
+        Can also be CurrentUser or AllUsers if you wish to install the modules in
+        such scope. The default value is 'output/RequiredModules' relative to
+        this script's path.
+
+    .PARAMETER Proxy
+        Specifies the URI to use for Proxy when attempting to bootstrap
+        PackageProvider and PowerShellGet.
+
+    .PARAMETER ProxyCredential
+        Specifies the credential to contact the Proxy when provided.
+
+    .PARAMETER Scope
+        Specifies the scope to bootstrap the PackageProvider and PSGet if not available.
+        THe default value is 'CurrentUser'.
+
+    .PARAMETER Gallery
+        Specifies the gallery to use when bootstrapping PackageProvider, PSGet and
+        when calling PSDepend (can be overridden in Dependency files). The default
+        value is 'PSGallery'.
+
+    .PARAMETER GalleryCredential
+        Specifies the credentials to use with the Gallery specified above.
+
+    .PARAMETER AllowOldPowerShellGetModule
+        Allow you to use a locally installed version of PowerShellGet older than
+        1.6.0 (not recommended). Default it will install the latest PowerShellGet
+        if an older version than 2.0 is detected.
+
+    .PARAMETER MinimumPSDependVersion
+        Allow you to specify a minimum version fo PSDepend, if you're after specific
+        features.
+
+    .PARAMETER AllowPrerelease
+        Not yet written.
+
+    .PARAMETER WithYAML
+        Not yet written.
+
+    .PARAMETER UseModuleFast
+        Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
+        faster.
+
+    .PARAMETER ModuleFastBleedingEdge
+        Specifies to use ModuleFast code that is in the ModuleFast's main branch
+        in its GitHub repository. The parameter UseModuleFast must also be set to
+        true.
+
+    .PARAMETER UsePSResourceGet
+        Specifies to use the new PSResourceGet module instead of the (now legacy) PowerShellGet module.
+
+    .PARAMETER PSResourceGetVersion
+        String specifying the module version for PSResourceGet if the `UsePSResourceGet` switch is utilized.
+
+    .NOTES
+        Load defaults for parameters values from Resolve-Dependency.psd1 if not
+        provided as parameter.
+#>
 [CmdletBinding()]
 param
 (
     [Parameter()]
-    [String]
+    [System.String]
     $DependencyFile = 'RequiredModules.psd1',
 
     [Parameter()]
-    [String]
-    # Path for PSDepend to be bootstrapped and save other dependencies.
-    # Can also be CurrentUser or AllUsers if you wish to install the modules in such scope
-    # Default to $PWD.Path/output/modules
-    $PSDependTarget = (Join-Path $PSScriptRoot './output/RequiredModules'),
+    [System.String]
+    $PSDependTarget = (Join-Path -Path $PSScriptRoot -ChildPath 'output/RequiredModules'),
 
     [Parameter()]
-    [uri]
-    # URI to use for Proxy when attempting to Bootstrap PackageProvider & PowerShellGet
+    [System.Uri]
     $Proxy,
 
     [Parameter()]
-    # Credential to contact the Proxy when provided
-    [PSCredential]$ProxyCredential,
+    [System.Management.Automation.PSCredential]
+    $ProxyCredential,
 
     [Parameter()]
     [ValidateSet('CurrentUser', 'AllUsers')]
-    [String]
-    # Scope to bootstrap the PackageProvider and PSGet if not available
+    [System.String]
     $Scope = 'CurrentUser',
 
     [Parameter()]
-    [String]
-    # Gallery to use when bootstrapping PackageProvider, PSGet and when calling PSDepend (can be overridden in Dependency files)
+    [System.String]
     $Gallery = 'PSGallery',
 
     [Parameter()]
-    [PSCredential]
-    # Credentials to use with the Gallery specified above
+    [System.Management.Automation.PSCredential]
     $GalleryCredential,
 
-
     [Parameter()]
-    [switch]
-    # Allow you to use a locally installed version of PowerShellGet older than 1.6.0 (not recommended, default to $false)
+    [System.Management.Automation.SwitchParameter]
     $AllowOldPowerShellGetModule,
 
     [Parameter()]
-    [String]
-    # Allow you to specify a minimum version fo PSDepend, if you're after specific features.
+    [System.String]
     $MinimumPSDependVersion,
 
     [Parameter()]
-    [Switch]
+    [System.Management.Automation.SwitchParameter]
     $AllowPrerelease,
 
     [Parameter()]
-    [Switch]
-    $WithYAML
+    [System.Management.Automation.SwitchParameter]
+    $WithYAML,
+
+    [Parameter()]
+    [System.Collections.Hashtable]
+    $RegisterGallery,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UseModuleFast,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $ModuleFastBleedingEdge,
+
+    [Parameter()]
+    [System.String]
+    $ModuleFastVersion,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePSResourceGet,
+
+    [Parameter()]
+    [System.String]
+    $PSResourceGetVersion,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePowerShellGetCompatibilityModule,
+
+    [Parameter()]
+    [System.String]
+    $UsePowerShellGetCompatibilityModuleVersion
 )
 
-# Load Defaults for parameters values from Resolve-Dependency.psd1 if not provided as parameter
 try
 {
-    Write-Verbose -Message "Importing Bootstrap default parameters from '$PSScriptRoot/Resolve-Dependency.psd1'."
-    $ResolveDependencyDefaults = Import-PowerShellDataFile -Path (Join-Path $PSScriptRoot '.\Resolve-Dependency.psd1' -Resolve -ErrorAction Stop)
-    $ParameterToDefault = $MyInvocation.MyCommand.ParameterSets.Where{ $_.Name -eq $PSCmdlet.ParameterSetName }.Parameters.Keys
-    if ($ParameterToDefault.Count -eq 0)
+    if ($PSVersionTable.PSVersion.Major -le 5)
     {
-        $ParameterToDefault = $MyInvocation.MyCommand.Parameters.Keys
-    }
-    # Set the parameters available in the Parameter Set, or it's not possible to choose yet, so all parameters are an option
-    foreach ($ParamName in $ParameterToDefault)
-    {
-        if (-Not $PSBoundParameters.Keys.Contains($ParamName) -and $ResolveDependencyDefaults.ContainsKey($ParamName))
+        if (-not (Get-Command -Name 'Import-PowerShellDataFile' -ErrorAction 'SilentlyContinue'))
         {
-            Write-Verbose -Message "Setting $ParamName with $($ResolveDependencyDefaults[$ParamName])"
+            Import-Module -Name Microsoft.PowerShell.Utility -RequiredVersion '3.1.0.0'
+        }
+    }
+
+    Write-Verbose -Message 'Importing Bootstrap default parameters from ''$PSScriptRoot/Resolve-Dependency.psd1''.'
+
+    $resolveDependencyConfigPath = Join-Path -Path $PSScriptRoot -ChildPath '.\Resolve-Dependency.psd1' -Resolve -ErrorAction 'Stop'
+
+    $resolveDependencyDefaults = Import-PowerShellDataFile -Path $resolveDependencyConfigPath
+
+    $parameterToDefault = $MyInvocation.MyCommand.ParameterSets.Where{ $_.Name -eq $PSCmdlet.ParameterSetName }.Parameters.Keys
+
+    if ($parameterToDefault.Count -eq 0)
+    {
+        $parameterToDefault = $MyInvocation.MyCommand.Parameters.Keys
+    }
+
+    # Set the parameters available in the Parameter Set, or it's not possible to choose yet, so all parameters are an option.
+    foreach ($parameterName in $parameterToDefault)
+    {
+        if (-not $PSBoundParameters.Keys.Contains($parameterName) -and $resolveDependencyDefaults.ContainsKey($parameterName))
+        {
+            Write-Verbose -Message "Setting parameter '$parameterName' to value '$($resolveDependencyDefaults[$parameterName])'."
+
             try
             {
-                $variableValue = $ResolveDependencyDefaults[$ParamName]
-                if ($variableValue -is [string])
+                $variableValue = $resolveDependencyDefaults[$parameterName]
+
+                if ($variableValue -is [System.String])
                 {
                     $variableValue = $ExecutionContext.InvokeCommand.ExpandString($variableValue)
                 }
-                $PSBoundParameters.Add($ParamName, $variableValue)
-                Set-Variable -Name $ParamName -value $variableValue -Force -ErrorAction SilentlyContinue
+
+                $PSBoundParameters.Add($parameterName, $variableValue)
+
+                Set-Variable -Name $parameterName -Value $variableValue -Force -ErrorAction 'SilentlyContinue'
             }
             catch
             {
-                Write-Verbose -Message "Error adding default for $ParamName : $($_.Exception.Message)"
+                Write-Verbose -Message "Error adding default for $parameterName : $($_.Exception.Message)."
             }
         }
     }
 }
 catch
 {
-    Write-Warning -Message "Error attempting to import Bootstrap's default parameters from $(Join-Path $PSScriptRoot '.\Resolve-Dependency.psd1'): $($_.Exception.Message)."
+    Write-Warning -Message "Error attempting to import Bootstrap's default parameters from '$resolveDependencyConfigPath': $($_.Exception.Message)."
 }
 
-Write-Progress -Activity "Bootstrap:" -PercentComplete 0 -CurrentOperation "NuGet Bootstrap"
-
-if (!(Get-PackageProvider -Name NuGet -ForceBootstrap -ErrorAction SilentlyContinue))
+# Handle when both ModuleFast and PSResourceGet is configured or/and passed as parameter.
+if ($UseModuleFast -and $UsePSResourceGet)
 {
-    $providerBootstrapParams = @{
-        Name           = 'nuget'
-        force          = $true
-        ForceBootstrap = $true
-        ErrorAction    = 'Stop'
-    }
+    Write-Information -MessageData 'Both ModuleFast and PSResourceGet is configured or/and passed as parameter.' -InformationAction 'Continue'
 
-    switch ($PSBoundParameters.Keys)
+    if ($PSVersionTable.PSVersion -ge '7.2')
     {
-        'Proxy'
-        {
-            $providerBootstrapParams.Add('Proxy', $Proxy)
-        }
-        'ProxyCredential'
-        {
-            $providerBootstrapParams.Add('ProxyCredential', $ProxyCredential)
-        }
-        'Scope'
-        {
-            $providerBootstrapParams.Add('Scope', $Scope)
-        }
-    }
+        $UsePSResourceGet = $false
 
-    if ($AllowPrerelease)
+        Write-Information -MessageData 'PowerShell 7.2 or higher being used, prefer ModuleFast over PSResourceGet.' -InformationAction 'Continue'
+    }
+    else
     {
-        $providerBootstrapParams.Add('AllowPrerelease', $true)
-    }
+        $UseModuleFast = $false
 
-    Write-Information "Bootstrap: Installing NuGet Package Provider from the web (Make sure Microsoft addresses/ranges are allowed)"
-    $null = Install-PackageProvider @providerBootstrapParams
-    $latestNuGetVersion = (Get-PackageProvider -Name NuGet -ListAvailable | Select-Object -First 1).Version.ToString()
-    Write-Information "Bootstrap: Importing NuGet Package Provider version $latestNuGetVersion to current session."
-    $Null = Import-PackageProvider -Name NuGet -RequiredVersion $latestNuGetVersion -Force
+        Write-Information -MessageData 'Windows PowerShell or PowerShell <=7.1 is being used, prefer PSResourceGet since ModuleFast is not supported on this version of PowerShell.' -InformationAction 'Continue'
+    }
 }
 
-Write-Progress -Activity "Bootstrap:" -PercentComplete 10 -CurrentOperation "Ensuring Gallery $Gallery is trusted"
-
-# Fail if the given PSGallery is not Registered
-$Policy = (Get-PSRepository $Gallery -ErrorAction Stop).InstallationPolicy
-Set-PSRepository -Name $Gallery -InstallationPolicy Trusted -ErrorAction Ignore
-try
+# Only bootstrap ModuleFast if it is not already imported.
+if ($UseModuleFast -and -not (Get-Module -Name 'ModuleFast'))
 {
-    Write-Progress -Activity "Bootstrap:" -PercentComplete 25 -CurrentOperation "Checking PowerShellGet"
-    # Ensure the module is loaded and retrieve the version you have
-    $PowerShellGetVersion = (Import-Module PowerShellGet -PassThru -ErrorAction SilentlyContinue).Version
-
-    Write-Verbose "Bootstrap: The PowerShellGet version is $PowerShellGetVersion"
-    # Versions below 1.6.0 are considered old, unreliable & not recommended
-    if (!$PowerShellGetVersion -or ($PowerShellGetVersion -lt [System.version]'1.6.0' -and !$AllowOldPowerShellGetModule))
+    try
     {
-        Write-Progress -Activity "Bootstrap:" -PercentComplete 40 -CurrentOperation "Installing newer version of PowerShellGet"
-        $InstallPSGetParam = @{
-            Name               = 'PowerShellGet'
-            Force              = $true
-            SkipPublisherCheck = $true
-            AllowClobber       = $true
-            Scope              = $Scope
-            Repository         = $Gallery
+        $moduleFastBootstrapScriptBlockParameters = @{}
+
+        if ($ModuleFastBleedingEdge)
+        {
+            Write-Information -MessageData 'ModuleFast is configured to use Bleeding Edge (directly from ModuleFast''s main branch).' -InformationAction 'Continue'
+
+            $moduleFastBootstrapScriptBlockParameters.UseMain = $true
+        }
+        elseif($ModuleFastVersion)
+        {
+            if ($ModuleFastVersion -notmatch 'v')
+            {
+                $ModuleFastVersion = 'v{0}' -f $ModuleFastVersion
+            }
+
+            Write-Information -MessageData ('ModuleFast is configured to use version {0}.' -f $ModuleFastVersion) -InformationAction 'Continue'
+
+            $moduleFastBootstrapScriptBlockParameters.Release = $ModuleFastVersion
+        }
+        else
+        {
+            Write-Information -MessageData 'ModuleFast is configured to use latest released version.' -InformationAction 'Continue'
+        }
+
+        $moduleFastBootstrapUri = 'bit.ly/modulefast' # cSpell: disable-line
+
+        Write-Debug -Message ('Using bootstrap script at {0}' -f $moduleFastBootstrapUri)
+
+        $invokeWebRequestParameters = @{
+            Uri         = $moduleFastBootstrapUri
+            ErrorAction = 'Stop'
+        }
+
+        $moduleFastBootstrapScript = Invoke-WebRequest @invokeWebRequestParameters
+
+        $moduleFastBootstrapScriptBlock = [ScriptBlock]::Create($moduleFastBootstrapScript)
+
+        & $moduleFastBootstrapScriptBlock @moduleFastBootstrapScriptBlockParameters
+    }
+    catch
+    {
+        Write-Warning -Message ('ModuleFast could not be bootstrapped. Reverting to PSResourceGet. Error: {0}' -f $_.Exception.Message)
+
+        $UseModuleFast = $false
+        $UsePSResourceGet = $true
+    }
+}
+
+if ($UsePSResourceGet)
+{
+    $psResourceGetModuleName = 'Microsoft.PowerShell.PSResourceGet'
+
+    # If PSResourceGet was used prior it will be locked and we can't replace it.
+    if ((Test-Path -Path "$PSDependTarget/$psResourceGetModuleName" -PathType 'Container') -and (Get-Module -Name $psResourceGetModuleName))
+    {
+        Write-Information -MessageData ('{0} is already bootstrapped and imported into the session. If there is a need to refresh the module, open a new session and resolve dependencies again.' -f $psResourceGetModuleName) -InformationAction 'Continue'
+    }
+    else
+    {
+        Write-Debug -Message ('{0} do not exist, saving the module to RequiredModules.' -f $psResourceGetModuleName)
+
+        $psResourceGetDownloaded = $false
+
+        try
+        {
+            if (-not $PSResourceGetVersion)
+            {
+                # Default to latest version if no version is passed in parameter or specified in configuration.
+                $psResourceGetUri = "https://www.powershellgallery.com/api/v2/package/$psResourceGetModuleName"
+            }
+            else
+            {
+                $psResourceGetUri = "https://www.powershellgallery.com/api/v2/package/$psResourceGetModuleName/$PSResourceGetVersion"
+            }
+
+            $invokeWebRequestParameters = @{
+                # TODO: Should support proxy parameters passed to the script.
+                Uri         = $psResourceGetUri
+                OutFile     = "$PSDependTarget/$psResourceGetModuleName.nupkg" # cSpell: ignore nupkg
+                ErrorAction = 'Stop'
+            }
+
+            $previousProgressPreference = $ProgressPreference
+            $ProgressPreference = 'SilentlyContinue'
+
+            # Bootstrapping Microsoft.PowerShell.PSResourceGet.
+            Invoke-WebRequest @invokeWebRequestParameters
+
+            $ProgressPreference = $previousProgressPreference
+
+            $psResourceGetDownloaded = $true
+        }
+        catch
+        {
+            Write-Warning -Message ('{0} could not be bootstrapped. Reverting to PowerShellGet. Error: {1}' -f $psResourceGetModuleName, $_.Exception.Message)
+        }
+
+        $UsePSResourceGet = $false
+
+        if ($psResourceGetDownloaded)
+        {
+            # On Windows PowerShell the command Expand-Archive do not like .nupkg as a zip archive extension.
+            $zipFileName = ((Split-Path -Path $invokeWebRequestParameters.OutFile -Leaf) -replace 'nupkg', 'zip')
+
+            $renameItemParameters = @{
+                Path    = $invokeWebRequestParameters.OutFile
+                NewName = $zipFileName
+                Force   = $true
+            }
+
+            Rename-Item @renameItemParameters
+
+            $psResourceGetZipArchivePath = Join-Path -Path (Split-Path -Path $invokeWebRequestParameters.OutFile -Parent) -ChildPath $zipFileName
+
+            $expandArchiveParameters = @{
+                Path            = $psResourceGetZipArchivePath
+                DestinationPath = "$PSDependTarget/$psResourceGetModuleName"
+                Force           = $true
+            }
+
+            Expand-Archive @expandArchiveParameters
+
+            Remove-Item -Path $psResourceGetZipArchivePath
+
+            Import-Module -Name $expandArchiveParameters.DestinationPath -Force
+
+            # Successfully bootstrapped PSResourceGet, so let's use it.
+            $UsePSResourceGet = $true
+        }
+    }
+
+    if ($UsePSResourceGet)
+    {
+        $psResourceGetModule = Get-Module -Name $psResourceGetModuleName
+
+        $psResourceGetModuleVersion = $psResourceGetModule.Version.ToString()
+
+        if ($psResourceGetModule.PrivateData.PSData.Prerelease)
+        {
+            $psResourceGetModuleVersion += '-{0}' -f $psResourceGetModule.PrivateData.PSData.Prerelease
+        }
+
+        Write-Information -MessageData ('Using {0} v{1}.' -f $psResourceGetModuleName, $psResourceGetModuleVersion) -InformationAction 'Continue'
+
+        if ($UsePowerShellGetCompatibilityModule)
+        {
+            $savePowerShellGetParameters = @{
+                Name            = 'PowerShellGet'
+                Path            = $PSDependTarget
+                Repository      = 'PSGallery'
+                TrustRepository = $true
+            }
+
+            if ($UsePowerShellGetCompatibilityModuleVersion)
+            {
+                $savePowerShellGetParameters.Version = $UsePowerShellGetCompatibilityModuleVersion
+
+                # Check if the version is a prerelease.
+                if ($UsePowerShellGetCompatibilityModuleVersion -match '\d+\.\d+\.\d+-.*')
+                {
+                    $savePowerShellGetParameters.Prerelease = $true
+                }
+            }
+
+            Save-PSResource @savePowerShellGetParameters
+
+            Import-Module -Name "$PSDependTarget/PowerShellGet"
+        }
+    }
+}
+
+# Check if legacy PowerShellGet and PSDepend must be bootstrapped.
+if (-not ($UseModuleFast -or $UsePSResourceGet))
+{
+    if ($PSVersionTable.PSVersion.Major -le 5)
+    {
+        <#
+            Making sure the imported PackageManagement module is not from PS7 module
+            path. The VSCode PS extension is changing the $env:PSModulePath and
+            prioritize the PS7 path. This is an issue with PowerShellGet because
+            it loads an old version if available (or fail to load latest).
+        #>
+        Get-Module -ListAvailable PackageManagement |
+            Where-Object -Property 'ModuleBase' -NotMatch 'powershell.7' |
+            Select-Object -First 1 |
+            Import-Module -Force
+    }
+
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 0 -CurrentOperation 'NuGet Bootstrap'
+
+    $importModuleParameters = @{
+        Name           = 'PowerShellGet'
+        MinimumVersion = '2.0'
+        MaximumVersion = '2.8.999'
+        ErrorAction    = 'SilentlyContinue'
+        PassThru       = $true
+    }
+
+    if ($AllowOldPowerShellGetModule)
+    {
+        $importModuleParameters.Remove('MinimumVersion')
+    }
+
+    $powerShellGetModule = Import-Module @importModuleParameters
+
+    # Install the package provider if it is not available.
+    $nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable -ErrorAction 'SilentlyContinue' |
+        Select-Object -First 1
+
+    if (-not $powerShellGetModule -and -not $nuGetProvider)
+    {
+        $providerBootstrapParameters = @{
+            Name           = 'NuGet'
+            Force          = $true
+            ForceBootstrap = $true
+            ErrorAction    = 'Stop'
+            Scope          = $Scope
         }
 
         switch ($PSBoundParameters.Keys)
         {
             'Proxy'
             {
-                $InstallPSGetParam.Add('Proxy', $Proxy)
+                $providerBootstrapParameters.Add('Proxy', $Proxy)
             }
+
             'ProxyCredential'
             {
-                $InstallPSGetParam.Add('ProxyCredential', $ProxyCredential)
+                $providerBootstrapParameters.Add('ProxyCredential', $ProxyCredential)
             }
-            'GalleryCredential'
+
+            'AllowPrerelease'
             {
-                $InstallPSGetParam.Add('Credential', $GalleryCredential)
+                $providerBootstrapParameters.Add('AllowPrerelease', $AllowPrerelease)
             }
         }
 
-        Install-Module @InstallPSGetParam
-        Remove-Module PowerShellGet -force -ErrorAction SilentlyContinue
-        Import-Module PowerShellGet -Force
-        $NewLoadedVersion = (Get-Module PowerShellGet).Version.ToString()
-        Write-Information "Bootstrap: PowerShellGet version loaded is $NewLoadedVersion"
-        Write-Progress -Activity "Bootstrap:" -PercentComplete 60 -CurrentOperation "Installing newer version of PowerShellGet"
+        Write-Information -MessageData 'Bootstrap: Installing NuGet Package Provider from the web (Make sure Microsoft addresses/ranges are allowed).'
+
+        $null = Install-PackageProvider @providerBootstrapParameters
+
+        $nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable | Select-Object -First 1
+
+        $nuGetProviderVersion = $nuGetProvider.Version.ToString()
+
+        Write-Information -MessageData "Bootstrap: Importing NuGet Package Provider version $nuGetProviderVersion to current session."
+
+        $Null = Import-PackageProvider -Name 'NuGet' -RequiredVersion $nuGetProviderVersion -Force
     }
 
-    # Try to import the PSDepend module from the available modules
-    try
+    if ($RegisterGallery)
     {
-        $ImportPSDependParam = @{
+        if ($RegisterGallery.ContainsKey('Name') -and -not [System.String]::IsNullOrEmpty($RegisterGallery.Name))
+        {
+            $Gallery = $RegisterGallery.Name
+        }
+        else
+        {
+            $RegisterGallery.Name = $Gallery
+        }
+
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 7 -CurrentOperation "Verifying private package repository '$Gallery'" -Completed
+
+        $previousRegisteredRepository = Get-PSRepository -Name $Gallery -ErrorAction 'SilentlyContinue'
+
+        if ($previousRegisteredRepository.SourceLocation -ne $RegisterGallery.SourceLocation)
+        {
+            if ($previousRegisteredRepository)
+            {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 9 -CurrentOperation "Re-registrering private package repository '$Gallery'" -Completed
+
+                Unregister-PSRepository -Name $Gallery
+
+                $unregisteredPreviousRepository = $true
+            }
+            else
+            {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 9 -CurrentOperation "Registering private package repository '$Gallery'" -Completed
+            }
+
+            Register-PSRepository @RegisterGallery
+        }
+    }
+
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 10 -CurrentOperation "Ensuring Gallery $Gallery is trusted"
+
+    # Fail if the given PSGallery is not registered.
+    $previousGalleryInstallationPolicy = (Get-PSRepository -Name $Gallery -ErrorAction 'Stop').Trusted
+
+    $updatedGalleryInstallationPolicy = $false
+
+    if ($previousGalleryInstallationPolicy -ne $true)
+    {
+        $updatedGalleryInstallationPolicy = $true
+
+        # Only change policy if the repository is not trusted
+        Set-PSRepository -Name $Gallery -InstallationPolicy 'Trusted' -ErrorAction 'Ignore'
+    }
+}
+
+try
+{
+    # Check if legacy PowerShellGet and PSDepend must be used.
+    if (-not ($UseModuleFast -or $UsePSResourceGet))
+    {
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 25 -CurrentOperation 'Checking PowerShellGet'
+
+        # Ensure the module is loaded and retrieve the version you have.
+        $powerShellGetVersion = (Import-Module -Name 'PowerShellGet' -PassThru -ErrorAction 'SilentlyContinue').Version
+
+        Write-Verbose -Message "Bootstrap: The PowerShellGet version is $powerShellGetVersion"
+
+        # Versions below 2.0 are considered old, unreliable & not recommended
+        if (-not $powerShellGetVersion -or ($powerShellGetVersion -lt [System.Version] '2.0' -and -not $AllowOldPowerShellGetModule))
+        {
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 40 -CurrentOperation 'Fetching newer version of PowerShellGet'
+
+            # PowerShellGet module not found, installing or saving it.
+            if ($PSDependTarget -in 'CurrentUser', 'AllUsers')
+            {
+                Write-Debug -Message "PowerShellGet module not found. Attempting to install from Gallery $Gallery."
+
+                Write-Warning -Message "Installing PowerShellGet in $PSDependTarget Scope."
+
+                $installPowerShellGetParameters = @{
+                    Name               = 'PowerShellGet'
+                    Force              = $true
+                    SkipPublisherCheck = $true
+                    AllowClobber       = $true
+                    Scope              = $Scope
+                    Repository         = $Gallery
+                    MaximumVersion     = '2.8.999'
+                }
+
+                switch ($PSBoundParameters.Keys)
+                {
+                    'Proxy'
+                    {
+                        $installPowerShellGetParameters.Add('Proxy', $Proxy)
+                    }
+
+                    'ProxyCredential'
+                    {
+                        $installPowerShellGetParameters.Add('ProxyCredential', $ProxyCredential)
+                    }
+
+                    'GalleryCredential'
+                    {
+                        $installPowerShellGetParameters.Add('Credential', $GalleryCredential)
+                    }
+                }
+
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation 'Installing newer version of PowerShellGet'
+
+                Install-Module @installPowerShellGetParameters
+            }
+            else
+            {
+                Write-Debug -Message "PowerShellGet module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
+
+                $saveModuleParameters = @{
+                    Name           = 'PowerShellGet'
+                    Repository     = $Gallery
+                    Path           = $PSDependTarget
+                    Force          = $true
+                    MaximumVersion = '2.8.999'
+                }
+
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation "Saving PowerShellGet from $Gallery to $Scope"
+
+                Save-Module @saveModuleParameters
+            }
+
+            Write-Debug -Message 'Removing previous versions of PowerShellGet and PackageManagement from session'
+
+            Get-Module -Name 'PowerShellGet' -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
+            Get-Module -Name 'PackageManagement' -All | Remove-Module -Force
+
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 65 -CurrentOperation 'Loading latest version of PowerShellGet'
+
+            Write-Debug -Message 'Importing latest PowerShellGet and PackageManagement versions into session'
+
+            if ($AllowOldPowerShellGetModule)
+            {
+                $powerShellGetModule = Import-Module -Name 'PowerShellGet' -Force -PassThru
+            }
+            else
+            {
+                Import-Module -Name 'PackageManagement' -MinimumVersion '1.4.8.1' -Force
+
+                $powerShellGetModule = Import-Module -Name 'PowerShellGet' -MinimumVersion '2.2.5' -Force -PassThru
+            }
+
+            $powerShellGetVersion = $powerShellGetModule.Version.ToString()
+
+            Write-Information -MessageData "Bootstrap: PowerShellGet version loaded is $powerShellGetVersion"
+        }
+
+        # Try to import the PSDepend module from the available modules.
+        $getModuleParameters = @{
+            Name          = 'PSDepend'
+            ListAvailable = $true
+        }
+
+        $psDependModule = Get-Module @getModuleParameters
+
+        if ($PSBoundParameters.ContainsKey('MinimumPSDependVersion'))
+        {
+            try
+            {
+                $psDependModule = $psDependModule | Where-Object -FilterScript { $_.Version -ge $MinimumPSDependVersion }
+            }
+            catch
+            {
+                throw ('There was a problem finding the minimum version of PSDepend. Error: {0}' -f $_)
+            }
+        }
+
+        if (-not $psDependModule)
+        {
+            Write-Debug -Message 'PSDepend module not found.'
+
+            # PSDepend module not found, installing or saving it.
+            if ($PSDependTarget -in 'CurrentUser', 'AllUsers')
+            {
+                Write-Debug -Message "Attempting to install from Gallery '$Gallery'."
+
+                Write-Warning -Message "Installing PSDepend in $PSDependTarget Scope."
+
+                $installPSDependParameters = @{
+                    Name               = 'PSDepend'
+                    Repository         = $Gallery
+                    Force              = $true
+                    Scope              = $PSDependTarget
+                    SkipPublisherCheck = $true
+                    AllowClobber       = $true
+                }
+
+                if ($MinimumPSDependVersion)
+                {
+                    $installPSDependParameters.Add('MinimumVersion', $MinimumPSDependVersion)
+                }
+
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 75 -CurrentOperation "Installing PSDepend from $Gallery"
+
+                Install-Module @installPSDependParameters
+            }
+            else
+            {
+                Write-Debug -Message "Attempting to Save from Gallery $Gallery to $PSDependTarget"
+
+                $saveModuleParameters = @{
+                    Name       = 'PSDepend'
+                    Repository = $Gallery
+                    Path       = $PSDependTarget
+                    Force      = $true
+                }
+
+                if ($MinimumPSDependVersion)
+                {
+                    $saveModuleParameters.add('MinimumVersion', $MinimumPSDependVersion)
+                }
+
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 75 -CurrentOperation "Saving PSDepend from $Gallery to $PSDependTarget"
+
+                Save-Module @saveModuleParameters
+            }
+        }
+
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 80 -CurrentOperation 'Importing PSDepend'
+
+        $importModulePSDependParameters = @{
             Name        = 'PSDepend'
             ErrorAction = 'Stop'
             Force       = $true
         }
 
-        if ($MinimumPSDependVersion)
+        if ($PSBoundParameters.ContainsKey('MinimumPSDependVersion'))
         {
-            $ImportPSDependParam.add('MinimumVersion', $MinimumPSDependVersion)
+            $importModulePSDependParameters.Add('MinimumVersion', $MinimumPSDependVersion)
         }
-        $null = Import-Module @ImportPSDependParam
-    }
-    catch
-    {
-        # PSDepend module not found, installing or saving it
-        if ($PSDependTarget -in 'CurrentUser', 'AllUsers')
+
+        # We should have successfully bootstrapped PSDepend. Fail if not available.
+        $null = Import-Module @importModulePSDependParameters
+
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 81 -CurrentOperation 'Invoke PSDepend'
+
+        if ($WithYAML)
         {
-            Write-Debug "PSDepend module not found. Attempting to install from Gallery $Gallery"
-            Write-Warning "Installing PSDepend in $PSDependTarget Scope"
-            $InstallPSDependParam = @{
-                Name               = 'PSDepend'
-                Repository         = $Gallery
-                Force              = $true
-                Scope              = $PSDependTarget
-                SkipPublisherCheck = $true
-                AllowClobber       = $true
-            }
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 82 -CurrentOperation 'Verifying PowerShell module PowerShell-Yaml'
 
-            if ($MinimumPSDependVersion)
+            if (-not (Get-Module -ListAvailable -Name 'PowerShell-Yaml'))
             {
-                $InstallPSDependParam.add('MinimumVersion', $MinimumPSDependVersion)
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 85 -CurrentOperation 'Installing PowerShell module PowerShell-Yaml'
+
+                Write-Verbose -Message "PowerShell-Yaml module not found. Attempting to Save from Gallery '$Gallery' to '$PSDependTarget'."
+
+                $SaveModuleParam = @{
+                    Name       = 'PowerShell-Yaml'
+                    Repository = $Gallery
+                    Path       = $PSDependTarget
+                    Force      = $true
+                }
+
+                Save-Module @SaveModuleParam
+            }
+            else
+            {
+                Write-Verbose -Message 'PowerShell-Yaml is already available'
             }
 
-            Write-Progress -Activity "Bootstrap:" -PercentComplete 75 -CurrentOperation "Installing PSDepend from $Gallery"
-            Install-Module @InstallPSDependParam
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 88 -CurrentOperation 'Importing PowerShell module PowerShell-Yaml'
+        }
+    }
+
+    if (Test-Path -Path $DependencyFile)
+    {
+        if ($UseModuleFast -or $UsePSResourceGet)
+        {
+            $requiredModules = Import-PowerShellDataFile -Path $DependencyFile
+
+            $requiredModules = $requiredModules.GetEnumerator() |
+                Where-Object -FilterScript { $_.Name -ne 'PSDependOptions' }
+
+            if ($UseModuleFast)
+            {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking ModuleFast'
+
+                Write-Progress -Activity 'ModuleFast:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
+
+                $modulesToSave = @(
+                    'PSDepend' # Always include PSDepend for backward compatibility.
+                )
+
+                if ($WithYAML)
+                {
+                    $modulesToSave += 'PowerShell-Yaml'
+                }
+
+                if ($UsePowerShellGetCompatibilityModule)
+                {
+                    Write-Debug -Message 'PowerShellGet compatibility module is configured to be used.'
+
+                    # This is needed to ensure that the PowerShellGet compatibility module works.
+                    $psResourceGetModuleName = 'Microsoft.PowerShell.PSResourceGet'
+
+                    if ($PSResourceGetVersion)
+                    {
+                        $modulesToSave += ('{0}:[{1}]' -f $psResourceGetModuleName, $PSResourceGetVersion)
+                    }
+                    else
+                    {
+                        $modulesToSave += $psResourceGetModuleName
+                    }
+
+                    $powerShellGetCompatibilityModuleName = 'PowerShellGet'
+
+                    if ($UsePowerShellGetCompatibilityModuleVersion)
+                    {
+                        $modulesToSave += ('{0}:[{1}]' -f $powerShellGetCompatibilityModuleName, $UsePowerShellGetCompatibilityModuleVersion)
+                    }
+                    else
+                    {
+                        $modulesToSave += $powerShellGetCompatibilityModuleName
+                    }
+                }
+
+                foreach ($requiredModule in $requiredModules)
+                {
+                    # If the RequiredModules.psd1 entry is an Hashtable then special handling is needed.
+                    if ($requiredModule.Value -is [System.Collections.Hashtable])
+                    {
+                        if (-not $requiredModule.Value.Version)
+                        {
+                            $requiredModuleVersion = 'latest'
+                        }
+                        else
+                        {
+                            $requiredModuleVersion = $requiredModule.Value.Version
+                        }
+
+                        if ($requiredModuleVersion -eq 'latest')
+                        {
+                            $moduleNameSuffix = ''
+
+                            if ($requiredModule.Value.Parameters.AllowPrerelease -eq $true)
+                            {
+                                <#
+                                    Adding '!' to the module name indicate to ModuleFast
+                                    that is should also evaluate pre-releases.
+                                #>
+                                $moduleNameSuffix = '!'
+                            }
+
+                            $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $moduleNameSuffix)
+                        }
+                        else
+                        {
+                            $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModuleVersion)
+                        }
+                    }
+                    else
+                    {
+                        if ($requiredModule.Value -eq 'latest')
+                        {
+                            $modulesToSave += $requiredModule.Name
+                        }
+                        else
+                        {
+                            # Handle different nuget version operators already present.
+                            if ($requiredModule.Value -match '[!|:|[|(|,|>|<|=]')
+                            {
+                                $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $requiredModule.Value)
+                            }
+                            else
+                            {
+                                # Assuming the version is a fixed version.
+                                $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModule.Value)
+                            }
+                        }
+                    }
+                }
+
+                Write-Debug -Message ("Required modules to retrieve plan for:`n{0}" -f ($modulesToSave | Out-String))
+
+                $installModuleFastParameters = @{
+                    Destination          = $PSDependTarget
+                    DestinationOnly      = $true
+                    NoPSModulePathUpdate = $true
+                    NoProfileUpdate      = $true
+                    Update               = $true
+                    Confirm              = $false
+                }
+
+                $moduleFastPlan = Install-ModuleFast -Specification $modulesToSave -Plan @installModuleFastParameters
+
+                Write-Debug -Message ("Missing modules that need to be saved:`n{0}" -f ($moduleFastPlan | Out-String))
+
+                if ($moduleFastPlan)
+                {
+                    # Clear all modules in plan from the current session so they can be fetched again.
+                    $moduleFastPlan.Name | Get-Module | Remove-Module -Force
+
+                    $moduleFastPlan | Install-ModuleFast @installModuleFastParameters
+                }
+                else
+                {
+                    Write-Verbose -Message 'All required modules were already up to date'
+                }
+
+                Write-Progress -Activity 'ModuleFast:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
+            }
+
+            if ($UsePSResourceGet)
+            {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking PSResourceGet'
+
+                $modulesToSave = @(
+                    @{
+                        Name = 'PSDepend'  # Always include PSDepend for backward compatibility.
+                    }
+                )
+
+                if ($WithYAML)
+                {
+                    $modulesToSave += @{
+                        Name = 'PowerShell-Yaml'
+                    }
+                }
+
+                # Prepare hashtable that can be concatenated to the Save-PSResource parameters.
+                foreach ($requiredModule in $requiredModules)
+                {
+                    # If the RequiredModules.psd1 entry is an Hashtable then special handling is needed.
+                    if ($requiredModule.Value -is [System.Collections.Hashtable])
+                    {
+                        $saveModuleHashtable = @{
+                            Name = $requiredModule.Name
+                        }
+
+                        if ($requiredModule.Value.Version -and $requiredModule.Value.Version -ne 'latest')
+                        {
+                            $saveModuleHashtable.Version = $requiredModule.Value.Version
+                        }
+
+                        if ($requiredModule.Value.Parameters.AllowPrerelease -eq $true)
+                        {
+                            $saveModuleHashtable.Prerelease = $true
+                        }
+
+                        $modulesToSave += $saveModuleHashtable
+                    }
+                    else
+                    {
+                        if ($requiredModule.Value -eq 'latest')
+                        {
+                            $modulesToSave += @{
+                                Name = $requiredModule.Name
+                            }
+                        }
+                        else
+                        {
+                            $modulesToSave += @{
+                                Name    = $requiredModule.Name
+                                Version = $requiredModule.Value
+                            }
+                        }
+                    }
+                }
+
+                $percentagePerModule = [System.Math]::Floor(100 / $modulesToSave.Length)
+
+                $progressPercentage = 0
+
+                Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies'
+
+                foreach ($currentModule in $modulesToSave)
+                {
+                    Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies' -Status ('Saving module {0}' -f $savePSResourceParameters.Name)
+
+                    $savePSResourceParameters = @{
+                        Path            = $PSDependTarget
+                        TrustRepository = $true
+                        Confirm         = $false
+                    }
+
+                    # Concatenate the module parameters to the Save-PSResource parameters.
+                    $savePSResourceParameters += $currentModule
+
+                    # Modules that Sampler depend on that cannot be refreshed without a new session.
+                    $skipModule = @('PowerShell-Yaml')
+
+                    if ($savePSResourceParameters.Name -in $skipModule -and (Get-Module -Name $savePSResourceParameters.Name))
+                    {
+                        Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies' -Status ('Skipping module {0}' -f $savePSResourceParameters.Name)
+
+                        Write-Information -MessageData ('Skipping the module {0} since it cannot be refresh while loaded into the session. To refresh the module open a new session and resolve dependencies again.' -f $savePSResourceParameters.Name) -InformationAction 'Continue'
+                    }
+                    else
+                    {
+                        # Clear all module from the current session so any new version fetched will be re-imported.
+                        Get-Module -Name $savePSResourceParameters.Name | Remove-Module -Force
+
+                        Save-PSResource @savePSResourceParameters -ErrorVariable 'savePSResourceError'
+
+                        if ($savePSResourceError)
+                        {
+                            Write-Warning -Message 'Save-PSResource could not save (replace) one or more dependencies. This can be due to the module is loaded into the session (and referencing assemblies). Close the current session and open a new session and try again.'
+                        }
+                    }
+
+                    $progressPercentage += $percentagePerModule
+                }
+
+                Write-Progress -Activity 'PSResourceGet:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
+            }
         }
         else
         {
-            Write-Debug "PSDepend module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
-            $SaveModuleParam = @{
-                Name       = 'PSDepend'
-                Repository = $Gallery
-                Path       = $PSDependTarget
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking PSDepend'
+
+            Write-Progress -Activity 'PSDepend:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
+
+            $psDependParameters = @{
+                Force = $true
+                Path  = $DependencyFile
             }
 
-            if ($MinimumPSDependVersion)
-            {
-                $SaveModuleParam.add('MinimumVersion', $MinimumPSDependVersion)
-            }
+            # TODO: Handle when the Dependency file is in YAML, and -WithYAML is specified.
+            Invoke-PSDepend @psDependParameters
 
-            Write-Progress -Activity "Bootstrap:" -PercentComplete 75 -CurrentOperation "Saving & Importing PSDepend from $Gallery to $Scope"
-            Save-Module @SaveModuleParam
+            Write-Progress -Activity 'PSDepend:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
         }
     }
-    finally
+    else
     {
-        Write-Progress -Activity "Bootstrap:" -PercentComplete 100 -CurrentOperation "Loading PSDepend"
-        # We should have successfully bootstrapped PSDepend. Fail if not available
-        Import-Module PSDepend -ErrorAction Stop
+        Write-Warning -Message "The dependency file '$DependencyFile' could not be found."
     }
 
-    if ($WithYAML)
-    {
-        if (-Not (Get-Module -ListAvailable -Name 'PowerShell-Yaml'))
-        {
-            Write-Verbose "PowerShell-Yaml module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
-            $SaveModuleParam = @{
-                Name       = 'PowerShell-Yaml'
-                Repository = $Gallery
-                Path       = $PSDependTarget
-            }
-
-            Save-Module @SaveModuleParam
-            Import-Module "PowerShell-Yaml" -ErrorAction Stop
-        }
-        else
-        {
-            Write-Verbose "PowerShell-Yaml is already available"
-        }
-    }
-
-    Write-Progress -Activity "PSDepend:" -PercentComplete 0 -CurrentOperation "Restoring Build Dependencies"
-    if (Test-Path $DependencyFile)
-    {
-        $PSDependParams = @{
-            Force = $true
-            Path  = $DependencyFile
-        }
-
-        # TODO: Handle when the Dependency file is in YAML, and -WithYAML is specified
-        Invoke-PSDepend @PSDependParams
-    }
-    Write-Progress -Activity "PSDepend:" -PercentComplete 100 -CurrentOperation "Dependencies restored" -Completed
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 100 -CurrentOperation 'Bootstrap complete' -Completed
 }
 finally
 {
-    # Reverting the Installation Policy for the given gallery
-    Set-PSRepository -Name $Gallery -InstallationPolicy $Policy
-    Write-Verbose "Project Bootstrapped, returning to Invoke-Build"
+    if ($RegisterGallery)
+    {
+        Write-Verbose -Message "Removing private package repository '$Gallery'."
+        Unregister-PSRepository -Name $Gallery
+    }
+
+    if ($unregisteredPreviousRepository)
+    {
+        Write-Verbose -Message "Reverting private package repository '$Gallery' to previous location URI:s."
+
+        $registerPSRepositoryParameters = @{
+            Name               = $previousRegisteredRepository.Name
+            InstallationPolicy = $previousRegisteredRepository.InstallationPolicy
+        }
+
+        if ($previousRegisteredRepository.SourceLocation)
+        {
+            $registerPSRepositoryParameters.SourceLocation = $previousRegisteredRepository.SourceLocation
+        }
+
+        if ($previousRegisteredRepository.PublishLocation)
+        {
+            $registerPSRepositoryParameters.PublishLocation = $previousRegisteredRepository.PublishLocation
+        }
+
+        if ($previousRegisteredRepository.ScriptSourceLocation)
+        {
+            $registerPSRepositoryParameters.ScriptSourceLocation = $previousRegisteredRepository.ScriptSourceLocation
+        }
+
+        if ($previousRegisteredRepository.ScriptPublishLocation)
+        {
+            $registerPSRepositoryParameters.ScriptPublishLocation = $previousRegisteredRepository.ScriptPublishLocation
+        }
+
+        Register-PSRepository @registerPSRepositoryParameters
+    }
+
+    if ($updatedGalleryInstallationPolicy -eq $true -and $previousGalleryInstallationPolicy -ne $true)
+    {
+        # Only try to revert installation policy if the repository exist
+        if ((Get-PSRepository -Name $Gallery -ErrorAction 'SilentlyContinue'))
+        {
+            # Reverting the Installation Policy for the given gallery if it was not already trusted
+            Set-PSRepository -Name $Gallery -InstallationPolicy 'Untrusted'
+        }
+    }
+
+    Write-Verbose -Message 'Project Bootstrapped, returning to Invoke-Build.'
 }

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -2,4 +2,14 @@
     Gallery         = 'PSGallery'
     AllowPrerelease = $false
     WithYAML        = $true
+
+    #UseModuleFast = $true
+    #ModuleFastVersion = '0.1.2'
+    #ModuleFastBleedingEdge = $true
+
+    UsePSResourceGet = $true
+    #PSResourceGetVersion = '1.0.1'
+
+    UsePowerShellGetCompatibilityModule = $true
+    UsePowerShellGetCompatibilityModuleVersion = '3.0.23-beta23'
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ stages:
       - job: Test_HQRM
         displayName: 'HQRM'
         pool:
-          vmImage: 'windows-2019'
+          vmImage: 'windows-latest'
         timeoutInMinutes: 0
         steps:
           - task: DownloadPipelineArtifact@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -143,9 +143,10 @@ stages:
               artifactName: $(testArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
 
-          - task: PublishCodeCoverageResults@2
+          - task: PublishCodeCoverageResults@1
             displayName: 'Publish Code Coverage to Azure DevOps'
             inputs:
+              codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
               pathToSources: '$(Build.SourcesDirectory)/$(sourceFolderName)/'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -143,10 +143,9 @@ stages:
               artifactName: $(testArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)'
 
-          - task: PublishCodeCoverageResults@1
+          - task: PublishCodeCoverageResults@2
             displayName: 'Publish Code Coverage to Azure DevOps'
             inputs:
-              codeCoverageTool: 'JaCoCo'
               summaryFileLocation: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
               pathToSources: '$(Build.SourcesDirectory)/$(sourceFolderName)/'
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,381 +1,538 @@
 <#
+    .DESCRIPTION
+        Bootstrap and build script for PowerShell module CI/CD pipeline.
 
-.DESCRIPTION
- Bootstrap and build script for PowerShell module pipeline
+    .PARAMETER Tasks
+        The task or tasks to run. The default value is '.' (runs the default task).
 
+    .PARAMETER CodeCoverageThreshold
+        The code coverage target threshold to uphold. Set to 0 to disable.
+        The default value is '' (empty string).
+
+    .PARAMETER BuildConfig
+        Not yet written.
+
+    .PARAMETER OutputDirectory
+        Specifies the folder to build the artefact into. The default value is 'output'.
+
+    .PARAMETER BuiltModuleSubdirectory
+        Subdirectory name to build the module (under $OutputDirectory). The default
+        value is '' (empty string).
+
+    .PARAMETER RequiredModulesDirectory
+        Can be a path (relative to $PSScriptRoot or absolute) to tell Resolve-Dependency
+        and PSDepend where to save the required modules. It is also possible to use
+        'CurrentUser' och 'AllUsers' to install missing dependencies. You can override
+        the value for PSDepend in the Build.psd1 build manifest. The default value is
+        'output/RequiredModules'.
+
+    .PARAMETER PesterScript
+        One or more paths that will override the Pester configuration in build
+        configuration file when running the build task Invoke_Pester_Tests.
+
+        If running Pester 5 test, use the alias PesterPath to be future-proof.
+
+    .PARAMETER PesterTag
+        Filter which tags to run when invoking Pester tests. This is used in the
+        Invoke-Pester.pester.build.ps1 tasks.
+
+    .PARAMETER PesterExcludeTag
+        Filter which tags to exclude when invoking Pester tests. This is used in
+        the Invoke-Pester.pester.build.ps1 tasks.
+
+    .PARAMETER DscTestTag
+        Filter which tags to run when invoking DSC Resource tests. This is used
+        in the DscResource.Test.build.ps1 tasks.
+
+    .PARAMETER DscTestExcludeTag
+        Filter which tags to exclude when invoking DSC Resource tests. This is
+        used in the DscResource.Test.build.ps1 tasks.
+
+    .PARAMETER ResolveDependency
+        Not yet written.
+
+    .PARAMETER BuildInfo
+        The build info object from ModuleBuilder. Defaults to an empty hashtable.
+
+    .PARAMETER AutoRestore
+        Not yet written.
+
+    .PARAMETER UseModuleFast
+        Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
+        faster.
+
+    .PARAMETER UsePSResourceGet
+        Specifies to use PSResourceGet instead of PowerShellGet to resolve dependencies
+        faster. This can also be configured in Resolve-Dependency.psd1.
+
+    .PARAMETER UsePowerShellGetCompatibilityModule
+        Specifies to use the compatibility module PowerShellGet. This parameter
+        only works then the method of downloading dependencies is PSResourceGet.
+        This can also be configured in Resolve-Dependency.psd1.
 #>
 [CmdletBinding()]
 param
 (
     [Parameter(Position = 0)]
-    [string[]]$Tasks = '.',
+    [System.String[]]
+    $Tasks = '.',
 
     [Parameter()]
-    [String]
+    [System.String]
     $CodeCoverageThreshold = '',
 
     [Parameter()]
-    [validateScript(
+    [System.String]
+    [ValidateScript(
         { Test-Path -Path $_ }
     )]
     $BuildConfig,
 
     [Parameter()]
-    # A Specific folder to build the artefact into.
+    [System.String]
     $OutputDirectory = 'output',
 
     [Parameter()]
-    # Subdirectory name to build the module (under $OutputDirectory)
+    [System.String]
     $BuiltModuleSubdirectory = '',
 
-    # Can be a path (relative to $PSScriptRoot or absolute) to tell Resolve-Dependency & PSDepend where to save the required modules,
-    # or use CurrentUser, AllUsers to target where to install missing dependencies
-    # You can override the value for PSDepend in the Build.psd1 build manifest
-    # This defaults to $OutputDirectory/modules (by default: ./output/modules)
     [Parameter()]
+    [System.String]
     $RequiredModulesDirectory = $(Join-Path 'output' 'RequiredModules'),
 
     [Parameter()]
-    [object[]]
+    # This alias is to prepare for the rename of this parameter to PesterPath when Pester 4 support is removed
+    [Alias('PesterPath')]
+    [System.Object[]]
     $PesterScript,
 
-    # Filter which tags to run when invoking Pester tests
-    # This is used in the Invoke-Pester.pester.build.ps1 tasks
     [Parameter()]
-    [string[]]
+    [System.String[]]
     $PesterTag,
 
-    # Filter which tags to exclude when invoking Pester tests
-    # This is used in the Invoke-Pester.pester.build.ps1 tasks
     [Parameter()]
-    [string[]]
+    [System.String[]]
     $PesterExcludeTag,
 
-    # Filter which tags to run when invoking DSC Resource tests
-    # This is used in the DscResource.Test.build.ps1 tasks
     [Parameter()]
-    [string[]]
+    [System.String[]]
     $DscTestTag,
 
-    # Filter which tags to exclude when invoking DSC Resource tests
-    # This is used in the DscResource.Test.build.ps1 tasks
     [Parameter()]
-    [string[]]
+    [System.String[]]
     $DscTestExcludeTag,
 
     [Parameter()]
     [Alias('bootstrap')]
-    [switch]$ResolveDependency,
+    [System.Management.Automation.SwitchParameter]
+    $ResolveDependency,
 
     [Parameter(DontShow)]
     [AllowNull()]
+    [System.Collections.Hashtable]
     $BuildInfo,
 
     [Parameter()]
-    [switch]
-    $AutoRestore
+    [System.Management.Automation.SwitchParameter]
+    $AutoRestore,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UseModuleFast,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePSResourceGet,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePowerShellGetCompatibilityModule
 )
 
-# The BEGIN block (at the end of this file) handles the Bootstrap of the Environment before Invoke-Build can run the tasks
-# if the -ResolveDependency (aka Bootstrap) is specified, the modules are already available, and can be auto loaded
+<#
+    The BEGIN block (at the end of this file) handles the Bootstrap of the Environment
+    before Invoke-Build can run the tasks if the parameter ResolveDependency (or
+    parameter alias Bootstrap) is specified.
+#>
 
 process
 {
-
     if ($MyInvocation.ScriptName -notLike '*Invoke-Build.ps1')
     {
-        # Only run the process block through InvokeBuild (Look at the Begin block at the bottom of this script)
+        # Only run the process block through InvokeBuild (look at the Begin block at the bottom of this script).
         return
     }
 
-    # Execute the Build Process from the .build.ps1 path.
-    Push-Location -Path $PSScriptRoot -StackName BeforeBuild
+    # Execute the Build process from the .build.ps1 path.
+    Push-Location -Path $PSScriptRoot -StackName 'BeforeBuild'
 
     try
     {
-        Write-Host -ForeGroundColor magenta "[build] Parsing defined tasks"
+        Write-Host -Object "[build] Parsing defined tasks" -ForeGroundColor Magenta
 
-        # Load Default BuildInfo if not provided as parameter
-        if (!$PSBoundParameters.ContainsKey('BuildInfo'))
+        # Load the default BuildInfo if the parameter BuildInfo is not set.
+        if (-not $PSBoundParameters.ContainsKey('BuildInfo'))
         {
             try
             {
-                if (Test-Path $BuildConfig)
+                if (Test-Path -Path $BuildConfig)
                 {
-                    $ConfigFile = (Get-Item -Path $BuildConfig)
-                    Write-Host "[build] Loading Configuration from $ConfigFile"
-                    $BuildInfo = switch -Regex ($ConfigFile.Extension)
+                    $configFile = Get-Item -Path $BuildConfig
+
+                    Write-Host -Object "[build] Loading Configuration from $configFile"
+
+                    $BuildInfo = switch -Regex ($configFile.Extension)
                     {
                         # Native Support for PSD1
                         '\.psd1'
                         {
+                            if (-not (Get-Command -Name Import-PowerShellDataFile -ErrorAction SilentlyContinue))
+                            {
+                                Import-Module -Name Microsoft.PowerShell.Utility -RequiredVersion 3.1.0.0
+                            }
+
                             Import-PowerShellDataFile -Path $BuildConfig
                         }
+
                         # Support for yaml when module PowerShell-Yaml is available
                         '\.[yaml|yml]'
                         {
-                            Import-Module -ErrorAction Stop -Name 'powershell-yaml'
-                            ConvertFrom-Yaml -Yaml (Get-Content -Raw $ConfigFile)
+                            Import-Module -Name 'powershell-yaml' -ErrorAction Stop
+
+                            ConvertFrom-Yaml -Yaml (Get-Content -Raw $configFile)
                         }
-                        # Native Support for JSON and JSONC (by Removing comments)
+
+                        # Support for JSON and JSONC (by Removing comments) when module PowerShell-Yaml is available
                         '\.[json|jsonc]'
                         {
-                            $JSONC = (Get-Content -Raw -Path $ConfigFile)
-                            $JSON = $JSONC -replace '(?m)\s*//.*?$' -replace '(?ms)/\*.*?\*/'
-                            # This should probably be converted to hashtable for splatting
-                            $JSON | ConvertFrom-Json
+                            $jsonFile = Get-Content -Raw -Path $configFile
+
+                            $jsonContent = $jsonFile -replace '(?m)\s*//.*?$' -replace '(?ms)/\*.*?\*/'
+
+                            # Yaml is superset of JSON.
+                            ConvertFrom-Yaml -Yaml $jsonContent
                         }
+
+                        # Unknown extension, return empty hashtable.
                         default
                         {
-                            Write-Error "Extension '$_' not supported. using @{}"
+                            Write-Error -Message "Extension '$_' not supported. using @{}"
+
                             @{ }
                         }
                     }
                 }
                 else
                 {
-                    Write-Host -Object "Configuration file $BuildConfig not found" -ForegroundColor Red
+                    Write-Host -Object "Configuration file '$($BuildConfig.FullName)' not found" -ForegroundColor Red
+
+                    # No config file was found, return empty hashtable.
                     $BuildInfo = @{ }
                 }
             }
             catch
             {
-                Write-Host -Object "Error loading Config $ConfigFile.`r`n Are you missing dependencies?" -ForegroundColor Yellow
-                Write-Host -Object "Make sure you run './build.ps1 -ResolveDependency -tasks noop' to restore the Required modules the first time" -ForegroundColor Yellow
+                $logMessage = "Error loading Config '$($BuildConfig.FullName)'.`r`nAre you missing dependencies?`r`nMake sure you run './build.ps1 -ResolveDependency -tasks noop' before running build to restore the required modules."
+
+                Write-Host -Object $logMessage -ForegroundColor Yellow
+
                 $BuildInfo = @{ }
-                Write-Error $_.Exception.Message
+
+                Write-Error -Message $_.Exception.Message
             }
         }
 
-        # If the Invoke-Build Task Header is specified in the Build Info, set it
+        # If the Invoke-Build Task Header is specified in the Build Info, set it.
         if ($BuildInfo.TaskHeader)
         {
-            Set-BuildHeader ([scriptblock]::Create($BuildInfo.TaskHeader))
+            Set-BuildHeader -Script ([scriptblock]::Create($BuildInfo.TaskHeader))
         }
 
-        # Import Tasks from modules via their exported aliases when defined in BUild Manifest
-        # https://github.com/nightroman/Invoke-Build/tree/master/Tasks/Import#example-2-import-from-a-module-with-tasks
-        if ($BuildInfo.containsKey('ModuleBuildTasks'))
-        {
-            foreach ($Module in $BuildInfo['ModuleBuildTasks'].Keys)
-            {
-                try
-                {
-                    Write-Host -ForegroundColor DarkGray -Verbose "Importing tasks from module $Module"
-                    $LoadedModule = Import-Module $Module -PassThru -ErrorAction Stop
-                    foreach ($TaskToExport in $BuildInfo['ModuleBuildTasks'].($Module))
-                    {
-                        $LoadedModule.ExportedAliases.GetEnumerator().Where{
-                            # using -like to support wildcard
-                            Write-Host -ForegroundColor DarkGray "`t Loading $($_.Key)..."
-                            $_.Key -like $TaskToExport
-                        }.ForEach{
-                            # Dot sourcing the Tasks via their exported aliases
-                            . (Get-Alias $_.Key)
-                        }
-                    }
-                }
-                catch
-                {
-                    Write-Host -ForegroundColor Red -Object "Could not load tasks for module $Module."
-                    Write-Error $_
-                }
-            }
-        }
-
-        # Loading Build Tasks defined in the .build/ folder (will override the ones imported above if same task name)
-        Get-ChildItem -Path ".build/" -Recurse -Include *.ps1 -ErrorAction Ignore | ForEach-Object {
-            "Importing file $($_.BaseName)" | Write-Verbose
-            . $_.FullName
-        }
-
-        # Synopsis: Empty task, useful to test the bootstrap process
-        task noop { }
-
-        # Define default task sequence ("."), can be overridden in the $BuildInfo
-        task . {
-            Write-Build Yellow "No sequence currently defined for the default task"
-        }
-
-        # Load Invoke-Build task sequences/workflows from $BuildInfo
-        Write-Host -ForegroundColor DarkGray "Adding Workflow from configuration:"
-        foreach ($Workflow in $BuildInfo.BuildWorkflow.keys)
-        {
-            Write-Verbose "Creating Build Workflow '$Workflow' with tasks $($BuildInfo.BuildWorkflow.($Workflow) -join ', ')"
-            $WorkflowItem = $BuildInfo.BuildWorkflow.($Workflow)
-            if ($WorkflowItem.Trim() -match '^\{(?<sb>[\w\W]*)\}$')
-            {
-                $WorkflowItem = [ScriptBlock]::Create($Matches['sb'])
-            }
-            Write-Host -ForegroundColor DarkGray "  +-> $Workflow"
-            task $Workflow $WorkflowItem
-        }
-
-        Write-Host -ForeGroundColor magenta "[build] Executing requested workflow: $($Tasks -join ', ')"
-
-    }
-    finally
-    {
-        Pop-Location -StackName BeforeBuild
-    }
-}
-
-Begin
-{
-    # Find build config if not specified
-    if (-not $BuildConfig) {
-        $config = Get-ChildItem -Path "$PSScriptRoot\*" -Include 'build.y*ml', 'build.psd1', 'build.json*' -ErrorAction:Ignore
-        if (-not $config -or ($config -is [array] -and $config.Length -le 0)) {
-            throw "No build configuration found. Specify path via -BuildConfig"
-        }
-        elseif ($config -is [array]) {
-            if ($config.Length -gt 1) {
-                throw "More than one build configuration found. Specify which one to use via -BuildConfig"
-            }
-            $BuildConfig = $config[0]
-        }
-        else {
-            $BuildConfig = $config
-        }
-    }
-    # Bootstrapping the environment before using Invoke-Build as task runner
-
-    if ($MyInvocation.ScriptName -notLike '*Invoke-Build.ps1')
-    {
-        Write-Host -foregroundColor Green "[pre-build] Starting Build Init"
-        Push-Location $PSScriptRoot -StackName BuildModule
-    }
-
-    if ($RequiredModulesDirectory -in @('CurrentUser', 'AllUsers'))
-    {
-        # Installing modules instead of saving them
-        Write-Host -foregroundColor Green "[pre-build] Required Modules will be installed for $RequiredModulesDirectory, not saved."
-        # Tell Resolve-Dependency to use provided scope as the -PSDependTarget if not overridden in Build.psd1
-        $PSDependTarget = $RequiredModulesDirectory
-    }
-    else
-    {
-        if (-Not (Split-Path -IsAbsolute -Path $OutputDirectory))
-        {
-            $OutputDirectory = Join-Path -Path $PSScriptRoot -ChildPath $OutputDirectory
-        }
-
-        # Resolving the absolute path to save the required modules to
-        if (-Not (Split-Path -IsAbsolute -Path $RequiredModulesDirectory))
-        {
-            $RequiredModulesDirectory = Join-Path -Path $PSScriptRoot -ChildPath $RequiredModulesDirectory
-        }
-
-        # Create the output/modules folder if not exists, or resolve the Absolute path otherwise
-        if (Resolve-Path $RequiredModulesDirectory -ErrorAction SilentlyContinue)
-        {
-            Write-Debug "[pre-build] Required Modules path already exist at $RequiredModulesDirectory"
-            $RequiredModulesPath = Convert-Path $RequiredModulesDirectory
-        }
-        else
-        {
-            Write-Host -foregroundColor Green "[pre-build] Creating required modules directory $RequiredModulesDirectory."
-            $RequiredModulesPath = (New-Item -ItemType Directory -Force -Path $RequiredModulesDirectory).FullName
-        }
-
-        # Prepending $RequiredModulesPath folder to PSModulePath to resolve from this folder FIRST
-        if ($RequiredModulesDirectory -notIn @('CurrentUser', 'AllUsers') -and
-            (($Env:PSModulePath -split [io.path]::PathSeparator) -notContains $RequiredModulesDirectory))
-        {
-            Write-Host -foregroundColor Green "[pre-build] Prepending '$RequiredModulesDirectory' folder to PSModulePath"
-            $Env:PSModulePath = $RequiredModulesDirectory + [io.path]::PathSeparator + $Env:PSModulePath
-        }
-
-        # Checking if the user should -ResolveDependency
-        if ((!(Get-Module -ListAvailable powershell-yaml) -or !(Get-Module -ListAvailable InvokeBuild) -or !(Get-Module -ListAvailable PSDepend)) -and !$ResolveDependency)
-        {
-            if ($AutoRestore -or !$PSBoundParameters.ContainsKey('Tasks') -or $Tasks -contains 'build')
-            {
-                Write-Host -ForegroundColor Yellow "[pre-build] Dependency missing, running './build.ps1 -ResolveDependency -Tasks noop' for you `r`n"
-                $ResolveDependency = $true
-            }
-            else
-            {
-                Write-Warning "Some required Modules are missing, make sure you first run with the '-ResolveDependency' parameter."
-                Write-Warning "Running 'build.ps1 -ResolveDependency -Tasks noop' will pull required modules without running the build task."
-            }
-        }
-
+        <#
+            Add BuildModuleOutput to PSModule Path environment variable.
+            Moved here (not in begin block) because build file can contains BuiltSubModuleDirectory value.
+        #>
         if ($BuiltModuleSubdirectory)
         {
-            if (-Not (Split-Path -IsAbsolute $BuiltModuleSubdirectory))
+            if (-not (Split-Path -IsAbsolute -Path $BuiltModuleSubdirectory))
             {
-                $BuildModuleOutput = Join-Path $OutputDirectory $BuiltModuleSubdirectory
+                $BuildModuleOutput = Join-Path -Path $OutputDirectory -ChildPath $BuiltModuleSubdirectory
             }
             else
             {
                 $BuildModuleOutput = $BuiltModuleSubdirectory
             }
+        } # test if BuiltModuleSubDirectory set in build config file
+        elseif ($BuildInfo.ContainsKey('BuiltModuleSubDirectory'))
+        {
+            $BuildModuleOutput = Join-Path -Path $OutputDirectory -ChildPath $BuildInfo['BuiltModuleSubdirectory']
         }
         else
         {
             $BuildModuleOutput = $OutputDirectory
         }
 
-        # Prepending $BuildModuleOutput folder to PSModulePath to resolve built module from this folder
-        if (($Env:PSModulePath -split [io.path]::PathSeparator) -notContains $BuildModuleOutput)
+        # Pre-pending $BuildModuleOutput folder to PSModulePath to resolve built module from this folder.
+        if ($powerShellModulePaths -notcontains $BuildModuleOutput)
         {
-            Write-Host -foregroundColor Green "[pre-build] Prepending '$BuildModuleOutput' folder to PSModulePath"
-            $Env:PSModulePath = $BuildModuleOutput + [io.path]::PathSeparator + $Env:PSModulePath
+            Write-Host -Object "[build] Pre-pending '$BuildModuleOutput' folder to PSModulePath" -ForegroundColor Green
+
+            $env:PSModulePath = $BuildModuleOutput + [System.IO.Path]::PathSeparator + $env:PSModulePath
         }
 
-        # Tell Resolve-Dependency to use $RequiredModulesPath as -PSDependTarget if not overridden in Build.psd1
-        $PSDependTarget = $RequiredModulesPath
-    }
-
-    if ($ResolveDependency)
-    {
-        Write-Host -Object "[pre-build] Resolving dependencies." -foregroundColor Green
-        $ResolveDependencyParams = @{ }
-
-        # If BuildConfig is a Yaml file, bootstrap powershell-yaml via ResolveDependency
-        if ($BuildConfig -match '\.[yaml|yml]$')
+        <#
+            Import Tasks from modules via their exported aliases when defined in Build Manifest.
+            https://github.com/nightroman/Invoke-Build/tree/master/Tasks/Import#example-2-import-from-a-module-with-tasks
+        #>
+        if ($BuildInfo.ContainsKey('ModuleBuildTasks'))
         {
-            $ResolveDependencyParams.add('WithYaml', $True)
-        }
-
-        $ResolveDependencyAvailableParams = (Get-Command -Name '.\Resolve-Dependency.ps1').parameters.keys
-        foreach ($CmdParameter in $ResolveDependencyAvailableParams)
-        {
-
-            # The parameter has been explicitly used for calling the .build.ps1
-            if ($MyInvocation.BoundParameters.ContainsKey($CmdParameter))
+            foreach ($module in $BuildInfo['ModuleBuildTasks'].Keys)
             {
-                $ParamValue = $MyInvocation.BoundParameters.ContainsKey($CmdParameter)
-                Write-Debug " adding  $CmdParameter :: $ParamValue [from user-provided parameters to Build.ps1]"
-                $ResolveDependencyParams.Add($CmdParameter, $ParamValue)
-            }
-            # Use defaults parameter value from Build.ps1, if any
-            else
-            {
-                if ($ParamValue = Get-Variable -Name $CmdParameter -ValueOnly -ErrorAction Ignore)
+                try
                 {
-                    Write-Debug " adding  $CmdParameter :: $ParamValue [from default Build.ps1 variable]"
-                    $ResolveDependencyParams.add($CmdParameter, $ParamValue)
+                    Write-Host -Object "Importing tasks from module $module" -ForegroundColor DarkGray
+
+                    $loadedModule = Import-Module -Name $module -PassThru -ErrorAction Stop
+
+                    foreach ($TaskToExport in $BuildInfo['ModuleBuildTasks'].($module))
+                    {
+                        $loadedModule.ExportedAliases.GetEnumerator().Where{
+                            Write-Host -Object "`t Loading $($_.Key)..." -ForegroundColor DarkGray
+
+                            # Using -like to support wildcard.
+                            $_.Key -like $TaskToExport
+                        }.ForEach{
+                            # Dot-sourcing the Tasks via their exported aliases.
+                            . (Get-Alias $_.Key)
+                        }
+                    }
+                }
+                catch
+                {
+                    Write-Host -Object "Could not load tasks for module $module." -ForegroundColor Red
+
+                    Write-Error -Message $_
                 }
             }
         }
 
-        Write-Host -foregroundColor Green "[pre-build] Starting bootstrap process."
-        .\Resolve-Dependency.ps1 @ResolveDependencyParams
+        # Loading Build Tasks defined in the .build/ folder (will override the ones imported above if same task name).
+        Get-ChildItem -Path '.build/' -Recurse -Include '*.ps1' -ErrorAction Ignore |
+            ForEach-Object {
+                "Importing file $($_.BaseName)" | Write-Verbose
+
+                . $_.FullName
+            }
+
+        # Synopsis: Empty task, useful to test the bootstrap process.
+        task noop { }
+
+        # Define default task sequence ("."), can be overridden in the $BuildInfo.
+        task . {
+            Write-Build -Object 'No sequence currently defined for the default task' -ForegroundColor Yellow
+        }
+
+        Write-Host -Object 'Adding Workflow from configuration:' -ForegroundColor DarkGray
+
+        # Load Invoke-Build task sequences/workflows from $BuildInfo.
+        foreach ($workflow in $BuildInfo.BuildWorkflow.keys)
+        {
+            Write-Verbose -Message "Creating Build Workflow '$Workflow' with tasks $($BuildInfo.BuildWorkflow.($Workflow) -join ', ')."
+
+            $workflowItem = $BuildInfo.BuildWorkflow.($workflow)
+
+            if ($workflowItem.Trim() -match '^\{(?<sb>[\w\W]*)\}$')
+            {
+                $workflowItem = [ScriptBlock]::Create($Matches['sb'])
+            }
+
+            Write-Host -Object "  +-> $workflow" -ForegroundColor DarkGray
+
+            task $workflow $workflowItem
+        }
+
+        Write-Host -Object "[build] Executing requested workflow: $($Tasks -join ', ')" -ForeGroundColor Magenta
+
+    }
+    finally
+    {
+        Pop-Location -StackName 'BeforeBuild'
+    }
+}
+
+begin
+{
+    # Find build config if not specified.
+    if (-not $BuildConfig)
+    {
+        $config = Get-ChildItem -Path "$PSScriptRoot\*" -Include 'build.y*ml', 'build.psd1', 'build.json*' -ErrorAction Ignore
+
+        if (-not $config -or ($config -is [System.Array] -and $config.Length -le 0))
+        {
+            throw 'No build configuration found. Specify path via parameter BuildConfig.'
+        }
+        elseif ($config -is [System.Array])
+        {
+            if ($config.Length -gt 1)
+            {
+                throw 'More than one build configuration found. Specify which path to use via parameter BuildConfig.'
+            }
+
+            $BuildConfig = $config[0]
+        }
+        else
+        {
+            $BuildConfig = $config
+        }
     }
 
-    if ($MyInvocation.ScriptName -notLike '*Invoke-Build.ps1')
+    # Bootstrapping the environment before using Invoke-Build as task runner
+
+    if ($MyInvocation.ScriptName -notlike '*Invoke-Build.ps1')
     {
-        Write-Verbose "Bootstrap completed. Handing back to InvokeBuild."
+        Write-Host -Object "[pre-build] Starting Build Init" -ForegroundColor Green
+
+        Push-Location $PSScriptRoot -StackName 'BuildModule'
+    }
+
+    if ($RequiredModulesDirectory -in @('CurrentUser', 'AllUsers'))
+    {
+        # Installing modules instead of saving them.
+        Write-Host -Object "[pre-build] Required Modules will be installed to the PowerShell module path that is used for $RequiredModulesDirectory." -ForegroundColor Green
+
+        <#
+            The variable $PSDependTarget will be used below when building the splatting
+            variable before calling Resolve-Dependency.ps1, unless overridden in the
+            file Resolve-Dependency.psd1.
+        #>
+        $PSDependTarget = $RequiredModulesDirectory
+    }
+    else
+    {
+        if (-not (Split-Path -IsAbsolute -Path $OutputDirectory))
+        {
+            $OutputDirectory = Join-Path -Path $PSScriptRoot -ChildPath $OutputDirectory
+        }
+
+        # Resolving the absolute path to save the required modules to.
+        if (-not (Split-Path -IsAbsolute -Path $RequiredModulesDirectory))
+        {
+            $RequiredModulesDirectory = Join-Path -Path $PSScriptRoot -ChildPath $RequiredModulesDirectory
+        }
+
+        # Create the output/modules folder if not exists, or resolve the Absolute path otherwise.
+        if (Resolve-Path -Path $RequiredModulesDirectory -ErrorAction SilentlyContinue)
+        {
+            Write-Debug -Message "[pre-build] Required Modules path already exist at $RequiredModulesDirectory"
+
+            $requiredModulesPath = Convert-Path -Path $RequiredModulesDirectory
+        }
+        else
+        {
+            Write-Host -Object "[pre-build] Creating required modules directory $RequiredModulesDirectory." -ForegroundColor Green
+
+            $requiredModulesPath = (New-Item -ItemType Directory -Force -Path $RequiredModulesDirectory).FullName
+        }
+
+        $powerShellModulePaths = $env:PSModulePath -split [System.IO.Path]::PathSeparator
+
+        # Pre-pending $requiredModulesPath folder to PSModulePath to resolve from this folder FIRST.
+        if ($RequiredModulesDirectory -notin @('CurrentUser', 'AllUsers') -and
+            ($powerShellModulePaths -notcontains $RequiredModulesDirectory))
+        {
+            Write-Host -Object "[pre-build] Pre-pending '$RequiredModulesDirectory' folder to PSModulePath" -ForegroundColor Green
+
+            $env:PSModulePath = $RequiredModulesDirectory + [System.IO.Path]::PathSeparator + $env:PSModulePath
+        }
+
+        $powerShellYamlModule = Get-Module -Name 'powershell-yaml' -ListAvailable
+        $invokeBuildModule = Get-Module -Name 'InvokeBuild' -ListAvailable
+        $psDependModule = Get-Module -Name 'PSDepend' -ListAvailable
+
+        # Checking if the user should -ResolveDependency.
+        if (-not ($powerShellYamlModule -and $invokeBuildModule -and $psDependModule) -and -not $ResolveDependency)
+        {
+            if ($AutoRestore -or -not $PSBoundParameters.ContainsKey('Tasks') -or $Tasks -contains 'build')
+            {
+                Write-Host -Object "[pre-build] Dependency missing, running './build.ps1 -ResolveDependency -Tasks noop' for you `r`n" -ForegroundColor Yellow
+
+                $ResolveDependency = $true
+            }
+            else
+            {
+                Write-Warning -Message "Some required Modules are missing, make sure you first run with the '-ResolveDependency' parameter. Running 'build.ps1 -ResolveDependency -Tasks noop' will pull required modules without running the build task."
+            }
+        }
+
+        <#
+            The variable $PSDependTarget will be used below when building the splatting
+            variable before calling Resolve-Dependency.ps1, unless overridden in the
+            file Resolve-Dependency.psd1.
+        #>
+        $PSDependTarget = $requiredModulesPath
+    }
+
+    if ($ResolveDependency)
+    {
+        Write-Host -Object "[pre-build] Resolving dependencies using preferred method." -ForegroundColor Green
+
+        $resolveDependencyParams = @{ }
+
+        # If BuildConfig is a Yaml file, bootstrap powershell-yaml via ResolveDependency.
+        if ($BuildConfig -match '\.[yaml|yml]$')
+        {
+            $resolveDependencyParams.Add('WithYaml', $true)
+        }
+
+        $resolveDependencyAvailableParams = (Get-Command -Name '.\Resolve-Dependency.ps1').Parameters.Keys
+
+        foreach ($cmdParameter in $resolveDependencyAvailableParams)
+        {
+            # The parameter has been explicitly used for calling the .build.ps1
+            if ($MyInvocation.BoundParameters.ContainsKey($cmdParameter))
+            {
+                $paramValue = $MyInvocation.BoundParameters.Item($cmdParameter)
+
+                Write-Debug " adding  $cmdParameter :: $paramValue [from user-provided parameters to Build.ps1]"
+
+                $resolveDependencyParams.Add($cmdParameter, $paramValue)
+            }
+            # Use defaults parameter value from Build.ps1, if any
+            else
+            {
+                $paramValue = Get-Variable -Name $cmdParameter -ValueOnly -ErrorAction Ignore
+
+                if ($paramValue)
+                {
+                    Write-Debug " adding  $cmdParameter :: $paramValue [from default Build.ps1 variable]"
+
+                    $resolveDependencyParams.Add($cmdParameter, $paramValue)
+                }
+            }
+        }
+
+        Write-Host -Object "[pre-build] Starting bootstrap process." -ForegroundColor Green
+
+        .\Resolve-Dependency.ps1 @resolveDependencyParams
+    }
+
+    if ($MyInvocation.ScriptName -notlike '*Invoke-Build.ps1')
+    {
+        Write-Verbose -Message "Bootstrap completed. Handing back to InvokeBuild."
+
         if ($PSBoundParameters.ContainsKey('ResolveDependency'))
         {
-            Write-Verbose "Dependency already resolved. Removing task"
+            Write-Verbose -Message "Dependency already resolved. Removing task."
+
             $null = $PSBoundParameters.Remove('ResolveDependency')
         }
-        Write-Host -foregroundColor Green "[build] Starting build with InvokeBuild."
+
+        Write-Host -Object "[build] Starting build with InvokeBuild." -ForegroundColor Green
+
         Invoke-Build @PSBoundParameters -Task $Tasks -File $MyInvocation.MyCommand.Path
-        Pop-Location -StackName BuildModule
+
+        Pop-Location -StackName 'BuildModule'
+
         return
     }
 }

--- a/build.yaml
+++ b/build.yaml
@@ -140,19 +140,9 @@ Pester:
 #      Pester Configuration (DscResource.Test)     #
 ####################################################
 DscTest:
-  Configuration:
-    Filter:
-      ExcludeTag:
-        - "Common Tests - New Error-Level Script Analyzer Rules"
-    Output:
-      Verbosity: Detailed
-      CIFormat: Auto
-    TestResult:
-      Enabled: true
-      OutputFormat: NUnitXML
-      OutputEncoding: ascii
-      OutputPath: ./output/testResults/NUnitXml_HQRM_Tests.xml
-Script:
+  OutputFormat: NUnitXML
+  ExcludeTag:
+    - 'Common Tests - New Error-Level Script Analyzer Rules'
   ExcludeSourceFile:
     - output
   ExcludeModuleFile:

--- a/build.yaml
+++ b/build.yaml
@@ -1,26 +1,5 @@
 ---
 ####################################################
-#          ModuleBuilder Configuration             #
-####################################################
-CopyPaths:
-  - en-US
-  - DSCResources
-  - Modules
-Encoding: UTF8
-VersionedOutputDirectory: true
-
-####################################################
-#   ModuleBuilder Dependent Modules Configuration  #
-####################################################
-
-NestedModule:
-  DscResource.Common:
-    CopyOnly: true
-    Path: ./output/RequiredModules/DscResource.Common
-    AddToManifest: false
-    Exclude: PSGetModuleInfo.xml
-
-####################################################
 #       Pipeline Configuration                     #
 ####################################################
 BuildWorkflow:
@@ -32,9 +11,17 @@ BuildWorkflow:
     - Clean
     - Build_Module_ModuleBuilder
     - Build_NestedModules_ModuleBuilder
-    - Create_changelog_release_output
+    - Create_Changelog_Release_Output
+
+  docs:
     - Generate_Conceptual_Help
     - Generate_Wiki_Content
+    - Generate_Markdown_For_Public_Commands
+    - Generate_External_Help_File_For_Public_Commands
+    - Clean_Markdown_Of_Public_Commands
+    - Generate_Wiki_Sidebar
+    - Clean_Markdown_Metadata
+    - Package_WikContent
 
   pack:
     - build
@@ -53,36 +40,47 @@ BuildWorkflow:
     - Publish_GitHub_Wiki_Content
     - Create_ChangeLog_GitHub_PR
 
+  Package_WikContent: |
+    {
+        param
+        (
+            $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
+            $ProjectName = (property ProjectName $(Get-SamplerProjectName -BuildRoot $BuildRoot)),
+            $BuildInfo = (property BuildInfo @{ })
+        )
+
+        "`tProject Name             = {0}" -f $ProjectName
+        "`tOutput Directory         = {0}" -f $OutputDirectory
+
+        $wikiOutputPath = Join-Path -Path $OutputDirectory -ChildPath 'WikiContent'
+        $wikiArchiveSourcePath = Join-Path -Path $wikiOutputPath -ChildPath '*'
+        $wikiPackagePath = Join-Path -Path $OutputDirectory -ChildPath 'WikiContent.zip'
+
+        "`tWiki Output Path         = $wikiOutputPath"
+        "`tWiki Archive Source Path = $wikiArchiveSourcePath"
+        "`tWiki Package Path        = $wikiPackagePath"
+
+        if (-not (Test-Path -Path $wikiOutputPath))
+        {
+            throw 'The Wiki Output Path does not exist. Please run the task Generate_Wiki_Content prior to running this task.'
+        }
+
+        # Overwrites any existing archive.
+        Compress-Archive -Path $wikiArchiveSourcePath -DestinationPath $wikiPackagePath -CompressionLevel 'Optimal' -Force -ErrorAction 'Stop'
+    }
+
 ####################################################
-#       PESTER Configuration                       #
+#          ModuleBuilder Configuration             #
 ####################################################
-
-Pester:
-  OutputFormat: NUnitXML
-  ExcludeFromCodeCoverage:
-    - Modules/DscResource.Common
-  Script:
-    - tests/Unit
-  ExcludeTag:
-  Tag:
-  CodeCoverageOutputFile: JaCoCo_coverage.xml
-  CodeCoverageOutputFileEncoding: ascii
-  CodeCoverageThreshold: 80
-
-DscTest:
-  OutputFormat: NUnitXML
-  ExcludeTag:
-    - 'Common Tests - New Error-Level Script Analyzer Rules'
-  ExcludeSourceFile:
-    - output
-  ExcludeModuleFile:
-    - Modules/DscResource.Common
-  MainGitBranch: main
-
-Resolve-Dependency:
-  Gallery: 'PSGallery'
-  AllowPrerelease: false
-  Verbose: false
+CopyPaths:
+  - en-US
+  - DSCResources
+  - Modules
+Prefix: prefix.ps1
+Suffix: suffix.ps1
+Encoding: UTF8
+VersionedOutputDirectory: true
+BuiltModuleSubdirectory: builtModule
 
 ModuleBuildTasks:
   Sampler:
@@ -90,6 +88,8 @@ ModuleBuildTasks:
   Sampler.GitHubTasks:
     - '*.ib.tasks'
   DscResource.DocGenerator:
+    - 'Task.*'
+  DscResource.Test:
     - 'Task.*'
 
 TaskHeader: |
@@ -103,10 +103,79 @@ TaskHeader: |
   Write-Build DarkGray "  $($Task.InvocationInfo.ScriptName):$($Task.InvocationInfo.ScriptLineNumber)"
   ""
 
+####################################################
+#     Dependent Modules Configuration (Sampler)    #
+####################################################
+NestedModule:
+  DscResource.Common:
+    CopyOnly: true
+    Path: ./output/RequiredModules/DscResource.Common
+    AddToManifest: false
+    Exclude: PSGetModuleInfo.xml
+
+####################################################
+#          Pester Configuration (Sampler)          #
+####################################################
+Pester:
+  Configuration:
+    Run:
+      Path:
+        - tests/Unit
+    Output:
+      Verbosity: Detailed
+      StackTraceVerbosity: Full
+      CIFormat: Auto
+    CodeCoverage:
+      CoveragePercentTarget: 80
+      OutputPath: JaCoCo_coverage.xml
+      OutputEncoding: ascii
+      UseBreakpoints: false
+    TestResult:
+      OutputFormat: NUnitXML
+      OutputEncoding: ascii
+  ExcludeFromCodeCoverage:
+    - Modules/DscResource.Common
+
+####################################################
+#      Pester Configuration (DscResource.Test)     #
+####################################################
+DscTest:
+  Pester:
+    Configuration:
+      Filter:
+        ExcludeTag:
+      Output:
+        Verbosity: Detailed
+        CIFormat: Auto
+      TestResult:
+        Enabled: true
+        OutputFormat: NUnitXML
+        OutputEncoding: ascii
+        OutputPath: ./output/testResults/NUnitXml_HQRM_Tests.xml
+  Script:
+    ExcludeSourceFile:
+      - output
+    ExcludeModuleFile:
+      - Modules/DscResource.Common
+    MainGitBranch: main
+
+####################################################
+#              PSDepend Configuration              #
+####################################################
+Resolve-Dependency:
+  Gallery: 'PSGallery'
+  AllowPrerelease: false
+  Verbose: false
+
+####################################################
+#               GitHub Configuration               #
+####################################################
 GitHubConfig:
   GitHubFilesToAdd:
     - 'CHANGELOG.md'
-  GitHubConfigUserName: dscbot
+  ReleaseAssets:
+    - output/WikiContent.zip
+  GitHubConfigUserName: dscbot # cSpell: disable-line
   GitHubConfigUserEmail: dsccommunity@outlook.com
   UpdateChangelogOnPrerelease: false
 
@@ -122,3 +191,18 @@ DscResource.DocGenerator:
       - '_(.+?)_' # Match Italic (underscore)
       - '\*\*(.+?)\*\*' # Match bold
       - '\*(.+?)\*' # Match Italic (asterisk)
+  Publish_GitHub_Wiki_Content:
+    Debug: false
+  Generate_Wiki_Content:
+    MofResourceMetadata:
+      Type: MofResource
+      Category: Resources
+    ClassResourceMetadata:
+      Type: ClassResource
+      Category: Resources
+    CompositeResourceMetadata:
+      Type: CompositeResource
+      Category: Resources
+  Generate_Wiki_Sidebar:
+     Debug: false
+     AlwaysOverwrite: true

--- a/build.yaml
+++ b/build.yaml
@@ -144,6 +144,7 @@ DscTest:
     Configuration:
       Filter:
         ExcludeTag:
+          - "Common Tests - New Error-Level Script Analyzer Rules"
       Output:
         Verbosity: Detailed
         CIFormat: Auto

--- a/build.yaml
+++ b/build.yaml
@@ -16,15 +16,13 @@ BuildWorkflow:
   docs:
     - Generate_Conceptual_Help
     - Generate_Wiki_Content
-    - Generate_Markdown_For_Public_Commands
-    - Generate_External_Help_File_For_Public_Commands
-    - Clean_Markdown_Of_Public_Commands
     - Generate_Wiki_Sidebar
     - Clean_Markdown_Metadata
     - Package_WikContent
 
   pack:
     - build
+    - docs
     - package_module_nupkg
 
   hqrmtest:
@@ -39,35 +37,6 @@ BuildWorkflow:
     - Publish_Release_To_GitHub
     - Publish_GitHub_Wiki_Content
     - Create_ChangeLog_GitHub_PR
-
-  Package_WikContent: |
-    {
-        param
-        (
-            $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
-            $ProjectName = (property ProjectName $(Get-SamplerProjectName -BuildRoot $BuildRoot)),
-            $BuildInfo = (property BuildInfo @{ })
-        )
-
-        "`tProject Name             = {0}" -f $ProjectName
-        "`tOutput Directory         = {0}" -f $OutputDirectory
-
-        $wikiOutputPath = Join-Path -Path $OutputDirectory -ChildPath 'WikiContent'
-        $wikiArchiveSourcePath = Join-Path -Path $wikiOutputPath -ChildPath '*'
-        $wikiPackagePath = Join-Path -Path $OutputDirectory -ChildPath 'WikiContent.zip'
-
-        "`tWiki Output Path         = $wikiOutputPath"
-        "`tWiki Archive Source Path = $wikiArchiveSourcePath"
-        "`tWiki Package Path        = $wikiPackagePath"
-
-        if (-not (Test-Path -Path $wikiOutputPath))
-        {
-            throw 'The Wiki Output Path does not exist. Please run the task Generate_Wiki_Content prior to running this task.'
-        }
-
-        # Overwrites any existing archive.
-        Compress-Archive -Path $wikiArchiveSourcePath -DestinationPath $wikiPackagePath -CompressionLevel 'Optimal' -Force -ErrorAction 'Stop'
-    }
 
 ####################################################
 #          ModuleBuilder Configuration             #
@@ -117,6 +86,16 @@ NestedModule:
 #          Pester Configuration (Sampler)          #
 ####################################################
 Pester:
+  # Pester 4 configuration
+  Script:
+    - tests/Unit
+  ExcludeTag:
+  Tag:
+  CodeCoverageOutputFile: JaCoCo_coverage.xml
+  CodeCoverageOutputFileEncoding: ascii
+  CodeCoverageThreshold: 80
+
+  # Pester 5 configuration
   Configuration:
     Run:
       Path:

--- a/build.yaml
+++ b/build.yaml
@@ -18,7 +18,7 @@ BuildWorkflow:
     - Generate_Wiki_Content
     - Generate_Wiki_Sidebar
     - Clean_Markdown_Metadata
-    - Package_WikContent
+    - Package_Wiki_Content
 
   pack:
     - build
@@ -37,35 +37,6 @@ BuildWorkflow:
     - Publish_Release_To_GitHub
     - Publish_GitHub_Wiki_Content
     - Create_ChangeLog_GitHub_PR
-
-  Package_WikContent: |
-    {
-        param
-        (
-            $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
-            $ProjectName = (property ProjectName $(Get-SamplerProjectName -BuildRoot $BuildRoot)),
-            $BuildInfo = (property BuildInfo @{ })
-        )
-
-        "`tProject Name             = {0}" -f $ProjectName
-        "`tOutput Directory         = {0}" -f $OutputDirectory
-
-        $wikiOutputPath = Join-Path -Path $OutputDirectory -ChildPath 'WikiContent'
-        $wikiArchiveSourcePath = Join-Path -Path $wikiOutputPath -ChildPath '*'
-        $wikiPackagePath = Join-Path -Path $OutputDirectory -ChildPath 'WikiContent.zip'
-
-        "`tWiki Output Path         = $wikiOutputPath"
-        "`tWiki Archive Source Path = $wikiArchiveSourcePath"
-        "`tWiki Package Path        = $wikiPackagePath"
-
-        if (-not (Test-Path -Path $wikiOutputPath))
-        {
-            throw 'The Wiki Output Path does not exist. Please run the task Generate_Wiki_Content prior to running this task.'
-        }
-
-        # Overwrites any existing archive.
-        Compress-Archive -Path $wikiArchiveSourcePath -DestinationPath $wikiPackagePath -CompressionLevel 'Optimal' -Force -ErrorAction 'Stop'
-    }
 
 ####################################################
 #          ModuleBuilder Configuration             #

--- a/build.yaml
+++ b/build.yaml
@@ -38,6 +38,35 @@ BuildWorkflow:
     - Publish_GitHub_Wiki_Content
     - Create_ChangeLog_GitHub_PR
 
+  Package_WikContent: |
+    {
+        param
+        (
+            $OutputDirectory = (property OutputDirectory (Join-Path $BuildRoot 'output')),
+            $ProjectName = (property ProjectName $(Get-SamplerProjectName -BuildRoot $BuildRoot)),
+            $BuildInfo = (property BuildInfo @{ })
+        )
+
+        "`tProject Name             = {0}" -f $ProjectName
+        "`tOutput Directory         = {0}" -f $OutputDirectory
+
+        $wikiOutputPath = Join-Path -Path $OutputDirectory -ChildPath 'WikiContent'
+        $wikiArchiveSourcePath = Join-Path -Path $wikiOutputPath -ChildPath '*'
+        $wikiPackagePath = Join-Path -Path $OutputDirectory -ChildPath 'WikiContent.zip'
+
+        "`tWiki Output Path         = $wikiOutputPath"
+        "`tWiki Archive Source Path = $wikiArchiveSourcePath"
+        "`tWiki Package Path        = $wikiPackagePath"
+
+        if (-not (Test-Path -Path $wikiOutputPath))
+        {
+            throw 'The Wiki Output Path does not exist. Please run the task Generate_Wiki_Content prior to running this task.'
+        }
+
+        # Overwrites any existing archive.
+        Compress-Archive -Path $wikiArchiveSourcePath -DestinationPath $wikiPackagePath -CompressionLevel 'Optimal' -Force -ErrorAction 'Stop'
+    }
+
 ####################################################
 #          ModuleBuilder Configuration             #
 ####################################################

--- a/build.yaml
+++ b/build.yaml
@@ -140,25 +140,24 @@ Pester:
 #      Pester Configuration (DscResource.Test)     #
 ####################################################
 DscTest:
-  Pester:
-    Configuration:
-      Filter:
-        ExcludeTag:
-          - "Common Tests - New Error-Level Script Analyzer Rules"
-      Output:
-        Verbosity: Detailed
-        CIFormat: Auto
-      TestResult:
-        Enabled: true
-        OutputFormat: NUnitXML
-        OutputEncoding: ascii
-        OutputPath: ./output/testResults/NUnitXml_HQRM_Tests.xml
-  Script:
-    ExcludeSourceFile:
-      - output
-    ExcludeModuleFile:
-      - Modules/DscResource.Common
-    MainGitBranch: main
+  Configuration:
+    Filter:
+      ExcludeTag:
+        - "Common Tests - New Error-Level Script Analyzer Rules"
+    Output:
+      Verbosity: Detailed
+      CIFormat: Auto
+    TestResult:
+      Enabled: true
+      OutputFormat: NUnitXML
+      OutputEncoding: ascii
+      OutputPath: ./output/testResults/NUnitXml_HQRM_Tests.xml
+Script:
+  ExcludeSourceFile:
+    - output
+  ExcludeModuleFile:
+    - Modules/DscResource.Common
+  MainGitBranch: main
 
 ####################################################
 #              PSDepend Configuration              #

--- a/source/DSCResources/DSC_OpticalDiskDriveLetter/README.md
+++ b/source/DSCResources/DSC_OpticalDiskDriveLetter/README.md
@@ -86,3 +86,19 @@ determine if the drive is a mounted ISO.
 
 This is not a complete list, as some other virtual devices from other vendors
 might not be available for testing.
+
+## Known Issues
+
+Some operating systems report the optical disk in the Win32_CDROMDrive list,
+but a volume that matches either the DeviceId or DriveLetter can not be found.
+The DriveLetter value appears as 'CdRom0' in the Win32_CDROMDrive list.
+This prevents the resource from matching the optical disk to a volume if the
+volume is not mounted.
+
+This appears to only be an issue with IDE optical drives. SCSI optical drives
+do not appear to have this issue.
+
+Therefore, this resource will not manage the optical disk if the volume can not
+be found and is not already mounted. The verbose logs will report this condition
+if detected. See [Issue #289](https://github.com/dsccommunity/StorageDsc/issues/289)
+for more information.

--- a/source/DSCResources/DSC_OpticalDiskDriveLetter/en-US/DSC_OpticalDiskDriveLetter.strings.psd1
+++ b/source/DSCResources/DSC_OpticalDiskDriveLetter/en-US/DSC_OpticalDiskDriveLetter.strings.psd1
@@ -17,5 +17,6 @@ ConvertFrom-StringData @'
     TestOpticalDiskWithoutDriveLetterCanBeManaged = Testing if the optical disk with Device Id '{0}' and without a drive letter assigned can be managed by this resource.
     TestOpticalDiskWithDriveLetterCanBeManaged = Testing if the optical disk with Device Id '{0}' and assigned drive letter '{1}' can be managed by this resource.
     OpticalDiskCanBeManagedStatus = The optical disk with Device Id '{0}' {1} be managed by this resource.
-    ErrorDiskIsNotAVirtualDisk = The specified disk is not a virtual disk.
+    DiskIsNotAVirtualDiskError = The specified disk is not a virtual disk.
+    TestOpticalDiskVolumeNotMatchableWarning = The optical disk with drive letter value '{0}' is not matchable to a volume and can not be managed by this resource.
 '@

--- a/source/Examples/README.md
+++ b/source/Examples/README.md
@@ -1,0 +1,16 @@
+
+# Examples
+
+This will help to understand how to setup certain scenarios with StorageDsc
+resource module.
+
+## Resource examples
+
+These are the links to the examples for each individual resource.
+
+- [Disk](Resources/Disk)
+- [DiskAccessPath](Resources/DiskAccessPath)
+- [MountImage](Resources/MountImage)
+- [OpticalDiskDriveLetter](Resources/OpticalDiskDriveLetter)
+- [WaitForDisk](Resources/WaitForDisk)
+- [WaitForVolume](Resources/WaitForVolume)


### PR DESCRIPTION
#### Pull Request (PR) description

This PR prevents an exception from occurring for some ODDs when the device is not mounted, but
appears with a DriveLetter as 'cdRom0' or some other value that is not a volume{guid} pattern.

Instead, a warning is reported and the device is reported as unmanageable.

This also updates the pipeline files to latest DSC community pattern and sampler tasks.
 
#### This Pull Request (PR) fixes the following issues

- Fixes #289 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/StorageDsc/290)
<!-- Reviewable:end -->
