### PR TITLE
Disk: AllocationUnitSize in examples should be UInt32 and not String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Disk:
+  - Updated AllocationUnitSize in examples to be a valid UInt32 value instead of a String
+
 ## [6.0.1] - 2024-06-11
 
 ### Fixed

--- a/source/Examples/Resources/Disk/2-Disk_InitializeDataDiskUsingUniqueId.ps1
+++ b/source/Examples/Resources/Disk/2-Disk_InitializeDataDiskUsingUniqueId.ps1
@@ -71,7 +71,7 @@ Configuration Disk_InitializeDataDiskUsingUniqueId
              DriveLetter = 'S'
              Size = 100GB
              FSFormat = 'ReFS'
-             AllocationUnitSize = 64KB
+             AllocationUnitSize = 65536
              DependsOn = '[WaitForDisk]Disk3'
         }
     }

--- a/source/Examples/Resources/WaitForDisk/1-WaitForDisk_InitializeDataDisk.ps1
+++ b/source/Examples/Resources/WaitForDisk/1-WaitForDisk_InitializeDataDisk.ps1
@@ -57,7 +57,7 @@ Configuration WaitForDisk_InitializeDataDisk
              DriveLetter = 'S'
              Size = 100GB
              FSFormat = 'ReFS'
-             AllocationUnitSize = 64KB
+             AllocationUnitSize = 65536
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Updated AllocationUnitSize in examples to be a valid UInt32 value instead of a String.

#### This Pull Request (PR) fixes the following issues

None

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/StorageDsc/293)
<!-- Reviewable:end -->
